### PR TITLE
Remove the use of `vars` and `hostvars` wherever possible.

### DIFF
--- a/roles/generate_readme/templates/readme.j2
+++ b/roles/generate_readme/templates/readme.j2
@@ -30,7 +30,7 @@ ansible-playbook playbooks/install_demo.yml -e @choose_demo.yml
 
 # Demo Repository
 
-This repository currently holds {{hostvars[inventory_hostname].items()|rejectattr('0', 'match', 'ansible_')|selectattr('1.name', 'defined')|sort(attribute='1.name')|count}} demos.
+This repository currently holds {{job_template_definitions.items()|sort(attribute='1.name')|count}} demos.
 
 ## Infrastructure Demos
 <table>
@@ -42,7 +42,7 @@ This repository currently holds {{hostvars[inventory_hostname].items()|rejectatt
     <th>Video Walkthrough</th>
     <th>Workshop Types</th>
   </tr>
-{% for key, value in hostvars[inventory_hostname].items()|rejectattr('0', 'match', 'ansible_')|selectattr('1.name', 'defined')|selectattr('1.category', 'match', 'infrastructure$')|sort(attribute='1.name') %}
+{% for key, value in job_template_definitions.items()|selectattr('1.category', 'match', 'infrastructure$')|sort(attribute='1.name') %}
   <tr>
     <td>{% if value.readme is defined%}<a href="{{ value.readme}}">{{value.name}}</a>{% else %}{{value.name}}{% endif %}</td>
     <td>{{value.author}}</td>
@@ -65,7 +65,7 @@ This repository currently holds {{hostvars[inventory_hostname].items()|rejectatt
     <th>Video Walkthrough</th>
     <th>Workshop Types</th>
   </tr>
-{% for key, value in hostvars[inventory_hostname].items()|rejectattr('0', 'match', 'ansible_')|selectattr('1.name', 'defined')|selectattr('1.category', 'match', 'network$')|sort(attribute='1.name') %}  <tr>
+{% for key, value in job_template_definitions.items()|selectattr('1.category', 'match', 'network$')|sort(attribute='1.name') %}  <tr>
     <td>{{ value.name }}</td>
     <td>{{ value.author }}</td>
     <td><pre>demo: {{key }}</pre></td>
@@ -87,7 +87,7 @@ This repository currently holds {{hostvars[inventory_hostname].items()|rejectatt
     <th>Video Walkthrough</th>
     <th>Workshop Types</th>
   </tr>
-{% for key, value in hostvars[inventory_hostname].items()|rejectattr('0', 'match', 'ansible_')|selectattr('1.name', 'defined')|selectattr('1.category', 'match', 'security$')|sort(attribute='1.name') %}  <tr>
+{% for key, value in job_template_definitions.items()|selectattr('1.category', 'match', 'security$')|sort(attribute='1.name') %}  <tr>
     <td>{{ value.name }}</td>
     <td>{{ value.author }}</td>
     <td><pre>demo: {{ key }}</pre></td>
@@ -109,7 +109,7 @@ This repository currently holds {{hostvars[inventory_hostname].items()|rejectatt
     <th>Video Walkthrough</th>
     <th>Workshop Types</th>
   </tr>
-{% for key, value in hostvars[inventory_hostname].items()|rejectattr('0', 'match', 'ansible_')|selectattr('1.name', 'defined')|selectattr('1.category', 'match', 'developer$')|sort(attribute='1.name') %}  <tr>
+{% for key, value in job_template_definitions.items()|selectattr('1.category', 'match', 'developer$')|sort(attribute='1.name') %}  <tr>
     <td>{{ value.name }}</td>
     <td>{{ value.author }}</td>
     <td><pre>demo: {{ key }}</pre></td>

--- a/roles/install_demo/tasks/job_template.yml
+++ b/roles/install_demo/tasks/job_template.yml
@@ -1,11 +1,11 @@
 ---
 - name: add tower project
   awx.awx.tower_project:
-    name: "{{ vars[demo].project.name }}"
-    description: "{{ vars[demo].project.description }}"
-    organization: "{{ vars[demo].project.organization }}"
-    scm_type: "{{ vars[demo].project.scm_type }}"
-    scm_url: "{{ vars[demo].project.scm_url }}"
+    name: "{{ job_template_definitions[demo].project.name }}"
+    description: "{{ job_template_definitions[demo].project.description }}"
+    organization: "{{ job_template_definitions[demo].project.organization }}"
+    scm_type: "{{ job_template_definitions[demo].project.scm_type }}"
+    scm_url: "{{ job_template_definitions[demo].project.scm_url }}"
     tower_username: "{{ my_tower_username }}"
     tower_password: "{{ my_tower_password }}"
     tower_host: "{{ my_tower_host }}"
@@ -14,58 +14,58 @@
 - name: show values
   debug:
     msg:
-      - "name: {{ vars[demo].name }}"
-      - "description: {{ vars[demo].description }}"
-      - "job_type: {{ vars[demo].job_type }}"
-      - "inventory: {{ vars[demo].inventory }}"
-      - "project: {{ vars[demo].project.name }}"
-      - "playbook: {{ vars[demo].playbook }}"
-      - "fact_caching_enabled: {{ vars[demo].fact_caching_enabled | default('false') }}"
-      - "credential: {{ vars[demo].credential }}"
-      - "survey_enabled: {{ vars[demo].survey_enabled  | default('false')  }}"
+      - "name: {{ job_template_definitions[demo].name }}"
+      - "description: {{ job_template_definitions[demo].description }}"
+      - "job_type: {{ job_template_definitions[demo].job_type }}"
+      - "inventory: {{ job_template_definitions[demo].inventory }}"
+      - "project: {{ job_template_definitions[demo].project.name }}"
+      - "playbook: {{ job_template_definitions[demo].playbook }}"
+      - "fact_caching_enabled: {{ job_template_definitions[demo].fact_caching_enabled | default('false') }}"
+      - "credential: {{ job_template_definitions[demo].credential }}"
+      - "survey_enabled: {{ job_template_definitions[demo].survey_enabled  | default('false')  }}"
 
 
 - name: add single job template without survey
   awx.awx.tower_job_template:
-    name: "{{ vars[demo].name }}"
-    description: "{{ vars[demo].description }}"
-    job_type: "{{ vars[demo].job_type }}"
-    inventory: "{{ vars[demo].inventory }}"
-    project: "{{ vars[demo].project.name }}"
-    playbook: "{{ vars[demo].playbook }}"
-    fact_caching_enabled: "{{ vars[demo].fact_caching_enabled | default('false') }}"
-    credential: "{{ vars[demo].credential }}"
-    survey_enabled: "{{ vars[demo].survey_enabled }}"
+    name: "{{ job_template_definitions[demo].name }}"
+    description: "{{ job_template_definitions[demo].description }}"
+    job_type: "{{ job_template_definitions[demo].job_type }}"
+    inventory: "{{ job_template_definitions[demo].inventory }}"
+    project: "{{ job_template_definitions[demo].project.name }}"
+    playbook: "{{ job_template_definitions[demo].playbook }}"
+    fact_caching_enabled: "{{ job_template_definitions[demo].fact_caching_enabled | default('false') }}"
+    credential: "{{ job_template_definitions[demo].credential }}"
+    survey_enabled: "{{ job_template_definitions[demo].survey_enabled }}"
     tower_username: "{{ my_tower_username }}"
     tower_password: "{{ my_tower_password }}"
     tower_host: "{{ my_tower_host }}"
     validate_certs: false
   when:
-    - workshop_type in vars[demo].workshop_type
-    - not vars[demo].survey_enabled
+    - workshop_type in job_template_definitions[demo].workshop_type
+    - not job_template_definitions[demo].survey_enabled
   register: add_job_template
   until: add_job_template is not failed
   retries: 5
 
 - name: add single job template with survey
   awx.awx.tower_job_template:
-    name: "{{ vars[demo].name }}"
-    description: "{{ vars[demo].description }}"
-    job_type: "{{ vars[demo].job_type }}"
-    inventory: "{{ vars[demo].inventory }}"
-    project: "{{ vars[demo].project.name }}"
-    playbook: "{{ vars[demo].playbook }}"
-    fact_caching_enabled: "{{ vars[demo].fact_caching_enabled | default('false') }}"
-    credential: "{{ vars[demo].credential }}"
-    survey_enabled: "{{ vars[demo].survey_enabled }}"
-    survey_spec: "{{ vars[demo].survey_spec }}"
+    name: "{{ job_template_definitions[demo].name }}"
+    description: "{{ job_template_definitions[demo].description }}"
+    job_type: "{{ job_template_definitions[demo].job_type }}"
+    inventory: "{{ job_template_definitions[demo].inventory }}"
+    project: "{{ job_template_definitions[demo].project.name }}"
+    playbook: "{{ job_template_definitions[demo].playbook }}"
+    fact_caching_enabled: "{{ job_template_definitions[demo].fact_caching_enabled | default('false') }}"
+    credential: "{{ job_template_definitions[demo].credential }}"
+    survey_enabled: "{{ job_template_definitions[demo].survey_enabled }}"
+    survey_spec: "{{ job_template_definitions[demo].survey_spec }}"
     tower_username: "{{ my_tower_username }}"
     tower_password: "{{ my_tower_password }}"
     tower_host: "{{ my_tower_host }}"
     validate_certs: false
   when:
-    - workshop_type in vars[demo].workshop_type
-    - vars[demo].survey_enabled
+    - workshop_type in job_template_definitions[demo].workshop_type
+    - job_template_definitions[demo].survey_enabled
   register: add_job_template
   until: add_job_template is not failed
   retries: 5

--- a/roles/install_demo/tasks/load_vars.yml
+++ b/roles/install_demo/tasks/load_vars.yml
@@ -2,7 +2,8 @@
 - name: include all demo vars from install_demo roll
   include_vars:
     dir: "vars"
+    name: job_template_definitions
 
-- name: will load vars from adjacent vars
+- name: will load vars
   debug:
-    msg: "variables loaded from install_demo role"
+    msg: "variables loaded from install_demo role into job_template_definitions"

--- a/roles/install_demo/tasks/main.yml
+++ b/roles/install_demo/tasks/main.yml
@@ -1,21 +1,24 @@
 ---
+- name: explicitly load vars under a subkey for reliable access
+  include_tasks: load_vars.yml
+
 - name: set facts from role vars
   set_fact:
-    demo_list: "{{ (dict(vars|dictsort|rejectattr('0', 'match', 'ansible_')|selectattr('1.name', 'defined')|selectattr('1.workshop_type', 'defined'))|dict2items)|map(attribute='key')|list }}"
-    full_demo_info: "{{ (dict(vars|dictsort|rejectattr('0', 'match', 'ansible_')|selectattr('1.name', 'defined')|selectattr('1.workshop_type', 'defined'))|dict2items) }}"
+    demo_list: "{{ ( job_template_definitions|map(attribute='key')|list }}"
+    full_demo_info: "{{ job_template_definitions|dict2items) }}"
 
 - name: provide info to terminal window
   debug:
     msg:
-      - "install {{ vars.demo }} on {{ my_tower_host }}"
+      - "install {{ demo }} on {{ my_tower_host }}"
       - "total demos: {{ demo_list | length }}"
       - "available demos are: {{ demo_list }}"
 
 - name: make sure demo is a valid demo
   assert:
     that:
-      - vars.demo is defined
-      - vars.demo in demo_list or vars.demo == "all"
+      - demo is defined
+      - demo in demo_list or demo == "all"
     msg:
       - "demo must be defined and be one of: {{ demo_list }}"
       - "full list can be found on https://github.com/ansible/product-demos"
@@ -35,11 +38,11 @@
   include_tasks: job_template.yml
   when:
     - demo != "all"
-    - vars[demo].workflow is not defined or not vars[demo].workflow
+    - job_template_definitions[demo].workflow is not defined or not job_template_definitions[demo].workflow
 
 - name: install single workflow
   include_tasks: workflow.yml
   when:
     - demo != "all"
-    - vars[demo].workflow is defined
-    - vars[demo].workflow
+    - job_template_definitions[demo].workflow is defined
+    - job_template_definitions[demo].workflow

--- a/roles/install_demo/tasks/workflow.yml
+++ b/roles/install_demo/tasks/workflow.yml
@@ -1,16 +1,16 @@
 ---
 # these tasks will install a workflow
 
-- name: "install all job templates in relation to workflow {{ hostvars[inventory_hostname][demo].name }}"
+- name: "install all job templates in relation to workflow {{ job_template_definitions[demo].name }}"
   include_tasks: add_job_template.yml
-  loop: "{{ hostvars[inventory_hostname][demo].job_templates|dict2items }}"
+  loop: "{{ job_template_definitions[demo].job_templates|dict2items }}"
 
-- name: "install workflow template {{ hostvars[inventory_hostname][demo].name }}"
+- name: "install workflow template {{ job_template_definitions[demo].name }}"
   awx.awx.tower_workflow_template:
-    name: "{{ hostvars[inventory_hostname][demo].name }}"
-    description: "{{ hostvars[inventory_hostname][demo].description }}"
-    organization: "{{ hostvars[inventory_hostname][demo].organization }}"
-    schema: "{{ hostvars[inventory_hostname][demo].schema }}"
+    name: "{{ job_template_definitions[demo].name }}"
+    description: "{{ job_template_definitions[demo].description }}"
+    organization: "{{ job_template_definitions[demo].organization }}"
+    schema: "{{ job_template_definitions[demo].schema }}"
     tower_username: "{{ my_tower_username }}"
     tower_password: "{{ my_tower_password }}"
     tower_host: "{{ my_tower_host }}"


### PR DESCRIPTION
`vars` operates inconsistently in different combinations of Ansible (full/base/core) and Python versions.

Variables are now instead explicitly loaded under a subkey, which also removes the need for filtering and makes access more explicit and semantic.

PR will be verified through ansible/workshops#1184.