### PR TITLE
removing ansible cfg till we find a way to add cloud hub creds

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,0 @@
-[defaults]
-collections_paths=./collections


### PR DESCRIPTION
removing ansible cfg till we find a way to add cloud hub creds in all workshops