### PR TITLE
Add Backup playbook to Network Demos

### DIFF
--- a/network/README.md
+++ b/network/README.md
@@ -46,7 +46,7 @@ You will be prompted by a survey for the following information:
 - Create a project token for your account. This step requires your own unique Gitlab username. https://gitlab.com/username/backups/-/settings/access_tokens
 
 At this point you should have a project url similar to this:
-https://gitlab.com/username/backups
+gitlab.com/username/backups
 
 You can view and delete your config files by accessing your own gitlab project url.
 

--- a/network/README.md
+++ b/network/README.md
@@ -36,3 +36,18 @@ A **`Network Inventory`** is created when setting up these demos and a dynamic s
   - [prefix_lists](https://github.com/nleiva/ansible-net-modules/blob/main/prefix_lists.cfg)
   - [snmp](https://github.com/nleiva/ansible-net-modules/blob/main/snmp.cfg)
   - [user](https://github.com/nleiva/ansible-net-modules/blob/main/user.cfg)
+
+**NETWORK / Backups to Gitlab** - Use this job-template to backup network device configurations to a Gitlab repository.
+
+***This demo requires the following pre-requisite items!***
+You will be prompted by a survey for the following information:
+- [Create a Gitlab Account](https://gitlab.com)
+- [Create a new project named 'backups'](https://gitlab.com/projects/new)
+- Create a project token for your account. This requires your unique Gitlab username. https://gitlab.com/<username>/backups/-/settings/access_tokens
+
+At this point you should have a project url similar to this:
+https://gitlab.com/<username>/backups
+
+You can view and delete your config files from accessing your own url.
+
+

--- a/network/README.md
+++ b/network/README.md
@@ -43,10 +43,10 @@ A **`Network Inventory`** is created when setting up these demos and a dynamic s
 You will be prompted by a survey for the following information:
 - [Create a Gitlab Account](https://gitlab.com)
 - [Create a new project named 'backups'](https://gitlab.com/projects/new)
-- Create a project token for your account. This requires your unique Gitlab username. https://gitlab.com/<username>/backups/-/settings/access_tokens
+- Create a project token for your account. This requires your unique Gitlab username. https://gitlab.com/username/backups/-/settings/access_tokens
 
 At this point you should have a project url similar to this:
-https://gitlab.com/<username>/backups
+https://gitlab.com/username/backups
 
 You can view and delete your config files from accessing your own url.
 

--- a/network/README.md
+++ b/network/README.md
@@ -43,7 +43,7 @@ A **`Network Inventory`** is created when setting up these demos and a dynamic s
 You will be prompted by a survey for the following information:
 - [Create a Gitlab Account](https://gitlab.com)
 - [Create a new project named 'backups'](https://gitlab.com/projects/new)
-- Create a project token for your account. This requires your unique Gitlab username. https://gitlab.com/username/backups/-/settings/access_tokens
+- Create a project token for your account. This step requires your own unique Gitlab username. https://gitlab.com/username/backups/-/settings/access_tokens
 
 At this point you should have a project url similar to this:
 https://gitlab.com/username/backups

--- a/network/README.md
+++ b/network/README.md
@@ -48,6 +48,6 @@ You will be prompted by a survey for the following information:
 At this point you should have a project url similar to this:
 https://gitlab.com/username/backups
 
-You can view and delete your config files from accessing your own url.
+You can view and delete your config files by accessing your own gitlab project url.
 
 

--- a/network/backup.yml
+++ b/network/backup.yml
@@ -1,0 +1,70 @@
+---
+- name: Backup Cisco Configs to GitLab
+  hosts: 
+  - localhost
+  - "{{ group }}" 
+  gather_facts: False
+  vars:
+    git_username: git config --global user.name {{ username }}
+    git_email: git config --global user.email {{ email }}
+    git_add: 'git add --all' 
+    git_commit: git commit --allow-empty -m "Changed by AAP2.4"
+    git_push: git push https://tdubiel1:{{ token }}@{{ url }}.git/ 
+  
+  tasks:
+    - name: Clone a Repo for backups
+      shell:
+        cmd: "git clone https://{{ url }}.git"
+        chdir: /tmp/
+      when: inventory_hostname == 'localhost'
+
+    - name: Backup ios configurations for selected devices
+      cisco.ios.ios_config:
+        backup: true
+        backup_options:
+          dir_path: /tmp/backups/
+      when: inventory_hostname in groups['ios']
+
+    - name: Backup iosxr configurations for selected devices
+      cisco.iosxr.iosxr_config:
+        backup: true
+        backup_options:
+          dir_path: /tmp/backups/
+      when: inventory_hostname in groups['iosxr']
+
+    - name: Backup iosxr configurations for selected devices
+      cisco.nxos.nxos_config:
+        backup: true
+        backup_options:
+          dir_path: /tmp/backups/
+      when: inventory_hostname in groups['nxos']
+
+    - name: This command list the files on the EE
+      shell:
+        cmd: ls
+        chdir: /tmp/backups/
+      when: inventory_hostname == 'localhost'
+      register: files
+
+    - name: Print Backup files on the screen
+      ansible.builtin.debug:
+        msg: "{{ files.stdout_lines }}"
+      when: inventory_hostname == 'localhost'
+
+    - name: Prepare GIT on EE for Credentials(vars/vault.yml)
+      ansible.builtin.shell:
+        cmd: "{{ item }}"
+        chdir: /tmp/backups/
+      when: inventory_hostname == 'localhost'
+      loop:
+        - "{{ git_username }}"
+        - "{{ git_email }}"
+        - "{{ git_add }}"
+        - "{{ git_commit }}"
+
+    - name: Push and Hide Token
+      ansible.builtin.shell:
+        cmd: "git push https://{{ username }}:{{ token }}@{{ url }}.git"
+        chdir: /tmp/backups/
+      when: inventory_hostname == 'localhost'
+      no_log: true

--- a/network/setup.yml
+++ b/network/setup.yml
@@ -117,3 +117,79 @@ controller_templates:
     use_fact_cache: true
     ask_job_type_on_launch: true
     survey_enabled: true
+
+  - name: "NETWORK / Backups to Gitlab"
+    job_type: run
+    organization: Default
+    inventory: Network Inventory
+    project: "Ansible official demo project"
+    playbook: "network/backup.yml"
+    notification_templates_started: Telemetry
+    notification_templates_success: Telemetry
+    notification_templates_error: Telemetry
+    execution_environment: Networking Execution Environment
+    use_fact_cache: true
+    credentials:
+      - "Workshop Credential"
+    survey_enabled: true
+    survey:
+      name: ''
+      description: ''
+      spec:
+        - choices: ''
+          default: ''
+          max: 1024
+          min: 0
+          new_question: false
+          question_description: ''
+          question_name: Please enter your Gitlab username
+          required: true
+          type: text
+          variable: username
+        - choices: ''
+          default: ''
+          max: 1024
+          min: 0
+          new_question: true
+          question_description: ''
+          question_name: Please enter your Gitlab email address
+          required: true
+          type: text
+          variable: email
+        - choices: ''
+          default: ''
+          max: 1024
+          min: 0
+          new_question: false
+          question_description: ''
+          question_name: Please enter the url for your Gitlab backup repo -  Example.
+            gitlab.com/username/backups - Note, do not include https://
+          required: true
+          type: text
+          variable: url
+        - choices: ''
+          default: ''
+          max: 1024
+          min: 0
+          new_question: true
+          question_description: ''
+          question_name: Please enter your Gitlab project token for your backups repo
+          required: true
+          type: password
+          variable: token
+        - choices:
+          - ios
+          - iosxr
+          - nxos
+          - routers
+          default: routers
+          max: 1024
+          min: 0
+          new_question: false
+          question_description: ''
+          question_name: Which Device Groups would you like to backup?
+          required: true
+          type: multiplechoice
+          variable: group
+
+  

--- a/network/setup.yml
+++ b/network/setup.yml
@@ -162,8 +162,8 @@ controller_templates:
           min: 0
           new_question: false
           question_description: ''
-          question_name: Please enter the url for your Gitlab backup repo -  Example.
-            gitlab.com/username/backups - Note, do not include https://
+          question_name: 'Please enter the url for your Gitlab backup repo - Example:
+            gitlab.com/username/backups - Note, do not prepend https:// or append the .git'
           required: true
           type: text
           variable: url


### PR DESCRIPTION
This demo backups the Devnet router configs to a Gitlab repo. It requires some prereqs that were added to the readme file.

NETWORK / Backups to Gitlab - Use this job-template to backup network device configurations to a Gitlab repository.

This demo requires the following pre-requisite items! You will be prompted by a survey for the following information:

[Create a Gitlab Account](https://gitlab.com/)
[Create a new project named 'backups'](https://gitlab.com/projects/new)
Create a project token for your account. This step requires your own unique Gitlab username. https://gitlab.com/username/backups/-/settings/access_tokens
At this point you should have a project url similar to this: gitlab.com/username/backups

You can view and delete your config files by accessing your own gitlab project url.