### PR TITLE
#113 solution - Windows AD domain reboots

### DIFF
--- a/windows/create_ad_domain.yml
+++ b/windows/create_ad_domain.yml
@@ -13,30 +13,23 @@
       ansible.windows.win_domain:
         dns_domain_name: ansible.local
         safe_mode_password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1) }}"
-      register: new_forest
+      notify: 
+        - Reboot host
+        - Wait for AD services
+        - Reboot again
+        - Wait for AD services again
 
-    - name: Reboot the target host
-      ansible.windows.win_reboot:
-        reboot_timeout: 3600
-      when: new_forest.reboot_required
-
-    - name: Wait up to 10min for AD web services to start
-      community.windows.win_wait_for_process:
-        process_name_exact: Microsoft.ActiveDirectory.WebServices
-        pre_wait_delay: 60
-        state: present
-        timeout: 600
-        sleep: 10
-      remote_user: Administrator
+    - name: Flush handlers
+      meta: flush_handlers
 
     - name: Create some groups
       community.windows.win_domain_group:
         name: "{{ item.name }}"
         scope: global
       loop:
-        - {name: "GroupA"}
-        - {name: "GroupB"}
-        - {name: "GroupC"}
+        - { name: "GroupA" }
+        - { name: "GroupB" }
+        - { name: "GroupC" }
       retries: 5
       delay: 10
 
@@ -47,8 +40,33 @@
         password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1) }}"
         update_password: on_create
       loop:
-        - {name: "UserA", groups: "GroupA"}
-        - {name: "UserB", groups: "GroupB"}
-        - {name: "UserC", groups: "GroupC"}
+        - { name: "UserA", groups: "GroupA" }
+        - { name: "UserB", groups: "GroupB" }
+        - { name: "UserC", groups: "GroupC" }
       retries: 5
       delay: 10
+
+  handlers:
+    - name: Reboot host
+      ansible.windows.win_reboot:
+        reboot_timeout: 3600
+
+    - name: Wait for AD services
+      community.windows.win_wait_for_process:
+        process_name_exact: Microsoft.ActiveDirectory.WebServices
+        pre_wait_delay: 60
+        state: present
+        timeout: 600
+        sleep: 10
+
+    - name: Reboot again
+      ansible.windows.win_reboot:
+        reboot_timeout: 3600
+
+    - name: Wait for AD services again
+      community.windows.win_wait_for_process:
+        process_name_exact: Microsoft.ActiveDirectory.WebServices
+        pre_wait_delay: 60
+        state: present
+        timeout: 600
+        sleep: 10


### PR DESCRIPTION
Facilitated multiple reboots via flushing handlers. This allows the playbook to run successfully in one run instead of multiple. Resolves #113 also Resolves #60