### PR TITLE
fix missing comment in win_scan_packages

### DIFF
--- a/collections/ansible_collections/demo/patching/plugins/modules/win_scan_packages.py
+++ b/collections/ansible_collections/demo/patching/plugins/modules/win_scan_packages.py
@@ -1,5 +1,5 @@
-!/usr/bin/env python
- -*- coding: utf-8 -*-
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 DOCUMENTATION = """
 ---


### PR DESCRIPTION
fixes a bug introduced by https://github.com/ansible/product-demos/commit/c0cd993c6918369afba2456b20126baf523cbf09#diff-b96b15b6317f28f23c0071daa9b0f176ead26855c8588c6167c30ba4ab8913aeL1 (missing comments)

Still don't know how it passes the CI

The target push CI is failing due to the missing comment:

```
error: cannot format collections/ansible_collections/demo/patching/plugins/modules/win_scan_packages.py: Cannot parse: 1:0: !/usr/bin/env python
Oh no! 💥 💔 💥
7 files left unchanged, 1 file failed to reformat.
```