### PR TITLE
More Windows in Workflow

### DIFF
--- a/cloud/setup.yml
+++ b/cloud/setup.yml
@@ -524,14 +524,24 @@ controller_workflows:
         unified_job_template: Cloud / AWS / VPC Report
         all_parents_must_converge: true
         always_nodes:
-          - Deploy Windows Blueprint
+          - Deploy Windows GUI Blueprint
           - Deploy RHEL8 Blueprint
           - Deploy RHEL9 Blueprint
-      - identifier: Deploy Windows Blueprint
+          - Deploy Windows Core Blueprint 
+      - identifier: Deploy Windows GUI Blueprint
         unified_job_template: Cloud / AWS / Create VM
         extra_data:
-          create_vm_vm_name: aws_win
+          create_vm_vm_name: aws_dc
           vm_blueprint: windows_full
+        success_nodes:
+          - Update Inventory
+        failure_nodes:
+          - Ticket - Instance Failed
+      - identifier: Deploy Windows Core Blueprint
+        unified_job_template: Cloud / AWS / Create VM
+        extra_data:
+          create_vm_vm_name: aws_win1
+          vm_blueprint: windows_core
         success_nodes:
           - Update Inventory
         failure_nodes:

--- a/cloud/setup.yml
+++ b/cloud/setup.yml
@@ -523,7 +523,7 @@ controller_workflows:
       - identifier: VPC Report
         unified_job_template: Cloud / AWS / VPC Report
         all_parents_must_converge: true
-        success_nodes:
+        always_nodes:
           - Deploy Windows Blueprint
           - Deploy RHEL8 Blueprint
           - Deploy RHEL9 Blueprint

--- a/cloud/setup.yml
+++ b/cloud/setup.yml
@@ -527,7 +527,7 @@ controller_workflows:
           - Deploy Windows GUI Blueprint
           - Deploy RHEL8 Blueprint
           - Deploy RHEL9 Blueprint
-          - Deploy Windows Core Blueprint 
+          - Deploy Windows Core Blueprint
       - identifier: Deploy Windows GUI Blueprint
         unified_job_template: Cloud / AWS / Create VM
         extra_data:


### PR DESCRIPTION
This PR sets the VM builds to proceed regardless of successful reports. This is a workaround to complete the resource building even if s3 permissions or conflicts arise.

Also, a 2nd windows node is deployed. 1 w/ GUI and 1 core so that join domain can be used w/o having to create another VM