### PR TITLE
switch to infra.controller_configuration.dispatch

### DIFF
--- a/cloud/setup.yml
+++ b/cloud/setup.yml
@@ -1,15 +1,6 @@
 ---
 user_message:
 
-controller_components:
-  - execution_environments
-  - projects
-  - credentials
-  - inventory_sources
-  - groups
-  - job_templates
-  - workflow_job_templates
-
 controller_execution_environments:
   - name: Cloud Services Execution Environment
     image: quay.io/scottharwell/cloud-ee:latest

--- a/linux/setup.yml
+++ b/linux/setup.yml
@@ -3,12 +3,6 @@ user_message:
   - Update the 'activation_key' and 'org_id' extra variables for 'LINUX / Register with Insights'. https://access.redhat.com/management/activation_keys
   - Update Credential for Insights Inventory with Red Hat account.
   - Add variables for system_roles. https://console.redhat.com/ansible/automation-hub/repo/published/redhat/rhel_system_roles
-controller_components:
-  - projects
-  - credential_types
-  - credentials
-  - inventory_sources
-  - job_templates
 
 controller_credential_types:
   - name: Insights Collection

--- a/multi_select_setup.yml
+++ b/multi_select_setup.yml
@@ -15,4 +15,4 @@
 
     - name: Default Components
       ansible.builtin.include_role:
-        name: "redhat_cop.controller_configuration.job_launch"
+        name: "infra.controller_configuration.job_launch"

--- a/network/setup.yml
+++ b/network/setup.yml
@@ -1,15 +1,6 @@
 ---
 user_message:
 
-controller_components:
-  - execution_environments
-  - projects
-  - inventories
-  - hosts
-  - inventory_sources
-  - inventory_source_update
-  - job_templates
-
 controller_execution_environments:
   - name: Networking Execution Environment
     image: quay.io/nleiva/ee-network-image

--- a/openshift/setup.yml
+++ b/openshift/setup.yml
@@ -1,8 +1,4 @@
 ---
-controller_components:
-  - credentials
-  - job_templates
-
 controller_credentials:
   - name: OpenShift Credential
     organization: Default

--- a/satellite/setup.yml
+++ b/satellite/setup.yml
@@ -1,14 +1,6 @@
 ---
 user_message:
 
-controller_components:
-  - credential_types
-  - credentials
-  - inventory_sources
-  - job_templates
-  - job_launch
-  - workflow_job_templates
-
 controller_credential_types:
   - name: Satellite Collection
     kind: cloud

--- a/setup_demo.yml
+++ b/setup_demo.yml
@@ -10,7 +10,7 @@
       vars:  # noqa var-naming[no-role-prefix]
         controller_execution_environments:
           - name: product-demos
-            image: http://quay.io/acme_corp/product-demos-ee:latest
+            image: quay.io/acme_corp/product-demos-ee:latest
         controller_organizations:
           - name: Default
             default_environment: product-demos

--- a/setup_demo.yml
+++ b/setup_demo.yml
@@ -6,13 +6,8 @@
   tasks:
     - name: Default Components
       ansible.builtin.include_role:
-        name: "redhat_cop.controller_configuration.{{ item }}"
-      loop: "{{ controller_components }}"
+        name: infra.controller_configuration.dispatch
       vars:  # noqa var-naming[no-role-prefix]
-        controller_components:
-          - notification_templates
-          - job_templates
-          - settings
         controller_execution_environments:
           - name: product-demos
             image: http://quay.io/acme_corp/product-demos-ee:latest
@@ -59,10 +54,7 @@
 
     - name: Demo Components
       ansible.builtin.include_role:
-        name: "redhat_cop.controller_configuration.{{ item }}"
-      loop: "{{ controller_components }}"
-      when:
-        - controller_components | d("") | length > 0
+        name: "infra.controller_configuration.dispatch"
 
     - name: Log Demo
       ansible.builtin.uri:

--- a/windows/setup.yml
+++ b/windows/setup.yml
@@ -2,10 +2,6 @@
 user_message: |
   ''
 
-controller_components:
-  - projects
-  - job_templates
-
 controller_projects:
   - name: Fact Scan
     organization: Default


### PR DESCRIPTION
- instead of looping through individual controller configuration roles, call the dispatch role.  note that setup_demo.yml calls the dispatch role twice, but using task vars for the first call should prevent the second call from reusing existing variable values.  closes #81
- no longer uses redhat_cop.controller_configuration collection, closes #118