### PR TITLE
Add deployment ID for bucket naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ choose_demo_example_aws.yml
 *artifact*.json
 **/roles/*
 !**/roles/requirements.yml
+.deployment_id

--- a/cloud/setup.yml
+++ b/cloud/setup.yml
@@ -1,4 +1,6 @@
 ---
+_deployment_id: "{{ lookup('file', playbook_dir + '/.deployment_id') }}"
+
 user_message:
 
 controller_execution_environments:
@@ -284,7 +286,7 @@ controller_templates:
     notification_templates_error: Telemetry
     extra_vars:
       aws_report: vpc
-      reports_aws_bucket_name: reports-pd-{{ lookup('file', playbook_dir + '/.deployment_id') }}
+      reports_aws_bucket_name: reports-pd-{{ _deployment_id }}
     survey_enabled: true
     survey:
       name: ''
@@ -313,6 +315,7 @@ controller_templates:
     notification_templates_error: Telemetry
     extra_vars:
       aws_report: tags
+      reports_aws_bucket_name: reports-pd-{{ _deployment_id }}
     survey_enabled: true
     survey:
       name: ''

--- a/cloud/setup.yml
+++ b/cloud/setup.yml
@@ -284,6 +284,7 @@ controller_templates:
     notification_templates_error: Telemetry
     extra_vars:
       aws_report: vpc
+      reports_aws_bucket_name: reports-pd-{{ lookup('file', playbook_dir + '/.deployment_id') }}
     survey_enabled: true
     survey:
       name: ''

--- a/setup_demo.yml
+++ b/setup_demo.yml
@@ -49,6 +49,10 @@
           - name: "SESSION_COOKIE_AGE"
             value: 180000
 
+    - name: Create reusable deployment ID
+      ansible.builtin.set_fact:
+        _deployment_id: '{{ lookup("ansible.builtin.password", "{{ playbook_dir }}/.deployment_id", chars=["ascii_letters", "digits"], length=5) }}'
+
     - name: "Include configuration for {{ demo }}"
       ansible.builtin.include_vars: "{{ demo }}/setup.yml"
 

--- a/setup_demo.yml
+++ b/setup_demo.yml
@@ -51,7 +51,7 @@
 
     - name: Create reusable deployment ID
       ansible.builtin.set_fact:
-        _deployment_id: '{{ lookup("ansible.builtin.password", "{{ playbook_dir }}/.deployment_id", chars=["ascii_letters", "digits"], length=5) }}'
+        _deployment_id: '{{ lookup("ansible.builtin.password", "{{ playbook_dir }}/.deployment_id", chars=["ascii_lowercase", "digits"], length=5) }}'
 
     - name: "Include configuration for {{ demo }}"
       ansible.builtin.include_vars: "{{ demo }}/setup.yml"


### PR DESCRIPTION
Initial setup will create a deployment ID stored in `{{ playbook_dir }}/.deployment_id`, which is used to override the default bucket name used in the  [aws.infrastructure_config_demos](https://github.com/ansible-content-lab/aws.infrastructure_config_demos) create_reports role.  This ID will also be available for use anywhere a unique identifier is needed for a product-demos task.

Closes #148
