### PR TITLE
Resolves NETWORK / DISA STIG job logging error

### DIFF
--- a/collections/ansible_collections/demo/compliance/roles/iosxeSTIG/tasks/main.yml
+++ b/collections/ansible_collections/demo/compliance/roles/iosxeSTIG/tasks/main.yml
@@ -137,14 +137,14 @@
     - (cmd_result.stdout|join('\n')).find('ip dns server') != -1
     - iosxeSTIG_stigrule_215823_Manage
 # R-215823 CISC-ND-000470
-- name : stigrule_215823_disable_identd
-  ignore_errors: "{{ ignore_all_errors }}"
-  notify: "save configuration"
-  ios_config:
-    defaults: yes
-    lines: "{{ iosxeSTIG_stigrule_215823_disable_identd_Lines }}"
-  when:
-    - iosxeSTIG_stigrule_215823_Manage
+# - name : stigrule_215823_disable_identd
+#   ignore_errors: "{{ ignore_all_errors }}"
+#   notify: "save configuration"
+#   ios_config:
+#     defaults: yes
+#     lines: "{{ iosxeSTIG_stigrule_215823_disable_identd_Lines }}"
+#   when:
+#     - iosxeSTIG_stigrule_215823_Manage
 # R-215823 CISC-ND-000470
 - name : stigrule_215823_disable_finger
   ignore_errors: "{{ ignore_all_errors }}"
@@ -378,9 +378,9 @@
 - name : stigrule_215837_host
   ignore_errors: "{{ ignore_all_errors }}"
   notify: "save configuration"
-  ios_logging:
-    dest: host
-    name: "{{ iosxeSTIG_stigrule_215837_host_Name }}"
+  ios_config:
+    lines:
+      - "logging {{ iosxeSTIG_stigrule_215837_host_Name }}"
   when: iosxeSTIG_stigrule_215837_Manage
 # R-215837 CISC-ND-001000
 # Please configure name IP address to a valid one.
@@ -397,16 +397,18 @@
 - name : stigrule_215838_ntp_server_1
   ignore_errors: "{{ ignore_all_errors }}"
   notify: "save configuration"
-  ios_ntp:
-    server: "{{ iosxeSTIG_stigrule_215838_ntp_server_1_Server }}"
+  cisco.ios.ios_config:
+    lines:
+      - "ntp server {{ iosxeSTIG_stigrule_215838_ntp_server_1_Server }}"
   when: iosxeSTIG_stigrule_215838_Manage
 # R-215838 CISC-ND-001030
 # Replace ntp servers' IP address before enabling.
 - name : stigrule_215838_ntp_server_2
   ignore_errors: "{{ ignore_all_errors }}"
   notify: "save configuration"
-  ios_ntp:
-    server: "{{ iosxeSTIG_stigrule_215838_ntp_server_2_Server }}"
+  cisco.ios.ios_config:
+    lines:
+      - "ntp server {{ iosxeSTIG_stigrule_215838_ntp_server_2_Server }}"
   when: iosxeSTIG_stigrule_215838_Manage
 # R-215840 CISC-ND-001050
 # service timestamps log datetime localtime is set in 215817.


### PR DESCRIPTION
Fixes issues #152
ios_logging is replaced by ios_logging_global
ios_ntp is replaced by ios_ntp_global

This update changes use of those modules to the base ios_config.  No changes are required to the defaults/main.yml file.

ERROR! couldn't resolve module/action 'ios_logging'. This often indicates a misspelling, missing collection, or incorrect module path. The error appears to be in '/runner/project/collections/ansible_collections/demo/compliance/roles/iosxeSTIG/tasks/main.yml': line 378, column 3, but may be elsewhere in the file depending on the exact syntax problem. The offending line appears to be:
# Please configure name IP address to a valid one.
- name : stigrule_215837_host ^ here