### PR TITLE
initial commit of a new EE build process

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -10,3 +10,4 @@ exclude_paths:
   - collections/ansible_collections/demo/compliance/roles/
   - roles/redhatofficial.*
   - .github/
+  - execution_environments/ee_contexts/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ choose_demo_example_aws.yml
 roles/*
 !roles/requirements.yml
 .deployment_id
+execution_environments/ee_contexts/

--- a/execution_environments/README.md
+++ b/execution_environments/README.md
@@ -1,0 +1,15 @@
+# Execution Environment Images for Ansible Product Demos
+
+When the Ansible Product Demos setup job template is run, it creates a number of execution environment definitions on the automation controller.  The content of this directory is used to create and update the default execution environment images defined during the setup process.
+
+Currently these execution environment images are created manually using the `build.sh` script, with a future goal of building in a CI pipeline when any EE definitions or requirements are updated.
+
+## Building the execution environment images
+
+1. `podman login registry.redhat.io` in order to pull the base EE images
+2. `./build.sh` to build the EE images and add them to your local podman image cache
+
+The `build.sh` script creates multiple EE images, each based on the ee-minimal image that comes with a different minor version of AAP.  These images are created in the "quay.io/ansible-product-demos" namespace.  Currently the script builds the following images:
+
+* quay.io/ansible-product-demos/product-demos-ee-23
+* quay.io/ansible-product-demos/product-demos-ee-24

--- a/execution_environments/ansible.cfg
+++ b/execution_environments/ansible.cfg
@@ -1,0 +1,15 @@
+[defaults]
+
+[galaxy]
+server_list = certified, validated, community_galaxy
+
+[galaxy_server.certified]
+url=https://cloud.redhat.com/api/automation-hub/content/published/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+[galaxy_server.validated]
+url=https://cloud.redhat.com/api/automation-hub/content/validated/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+[galaxy_server.community_galaxy]
+url=https://galaxy.ansible.com/

--- a/execution_environments/build.sh
+++ b/execution_environments/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# array of images to build
+ee_images=(
+    "product-demos-ee-23"
+    "product-demos-ee-24"
+)
+
+for ee in "${ee_images[@]}"
+do
+    # build EE image
+    ansible-builder build \
+        --file ${ee}.yml \
+        --context ./ee_contexts/${ee} \
+        --build-arg ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN \
+        --build-arg ANSIBLE_GALAXY_SERVER_VALIDATED_TOKEN \
+        -v 3 \
+        -t quay.io/ansible-product-demos/${ee}:$(date +%Y%m%d)
+
+    # tag EE image as latest
+    podman tag \
+        quay.io/ansible-product-demos/${ee}:$(date +%Y%m%d) \
+        quay.io/ansible-product-demos/${ee}:latest
+done

--- a/execution_environments/product-demos-ee-23.yml
+++ b/execution_environments/product-demos-ee-23.yml
@@ -1,0 +1,32 @@
+---
+version: 3
+images:
+  base_image:
+    name: registry.redhat.io/ansible-automation-platform-23/ee-minimal-rhel8:latest
+
+dependencies:
+  galaxy: requirements.yml
+
+additional_build_files:
+  # https://access.redhat.com/solutions/7024259
+  # download from access.redhat.com -> Downloads -> OpenShift Container Platform -> Packages
+  - src: openshift-clients-4.16.0-202408021139.p0.ge8fb3c0.assembly.stream.el8.x86_64.rpm
+    dest: rpms
+  - src: ansible.cfg
+    dest: configs
+
+options:
+  package_manager_path: /usr/bin/microdnf
+
+additional_build_steps:
+  prepend_base:
+    - RUN $PYCMD -m pip install --upgrade pip setuptools
+    - COPY _build/rpms/openshift-clients*.rpm /tmp/openshift-clients.rpm
+    - RUN $PKGMGR install bash-completion
+    - RUN rpm -ivh /tmp/openshift-clients.rpm
+  prepend_galaxy:
+    - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+    - ARG ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN
+    - ARG ANSIBLE_GALAXY_SERVER_VALIDATED_TOKEN
+
+...

--- a/execution_environments/product-demos-ee-24.yml
+++ b/execution_environments/product-demos-ee-24.yml
@@ -1,0 +1,32 @@
+---
+version: 3
+images:
+  base_image:
+    name: registry.redhat.io/ansible-automation-platform-24/ee-minimal-rhel8:latest
+
+dependencies:
+  galaxy: requirements.yml
+
+additional_build_files:
+  # https://access.redhat.com/solutions/7024259
+  # download from access.redhat.com -> Downloads -> OpenShift Container Platform -> Packages
+  - src: openshift-clients-4.16.0-202408021139.p0.ge8fb3c0.assembly.stream.el8.x86_64.rpm
+    dest: rpms
+  - src: ansible.cfg
+    dest: configs
+
+options:
+  package_manager_path: /usr/bin/microdnf
+
+additional_build_steps:
+  prepend_base:
+    - RUN $PYCMD -m pip install --upgrade pip setuptools
+    - COPY _build/rpms/openshift-clients*.rpm /tmp/openshift-clients.rpm
+    - RUN $PKGMGR install bash-completion
+    - RUN rpm -ivh /tmp/openshift-clients.rpm
+  prepend_galaxy:
+    - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+    - ARG ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN
+    - ARG ANSIBLE_GALAXY_SERVER_VALIDATED_TOKEN
+
+...

--- a/execution_environments/requirements.yml
+++ b/execution_environments/requirements.yml
@@ -1,0 +1,52 @@
+---
+collections:
+  - name: ansible.controller
+    version: ">=4.5.5"
+  - name: infra.ah_configuration
+    version: ">=2.0.6"
+  - name: infra.controller_configuration
+    version: ">=2.9.0"
+  - name: redhat_cop.controller_configuration
+    version: ">=2.3.1"
+  # linux
+  - name: ansible.posix
+    version: ">=1.5.4"
+  - name: community.general
+    version: ">=8.0.0"
+  - name: containers.podman
+    version: ">=1.12.1"
+  - name: redhat.insights
+    version: ">=1.2.2"
+  - name: redhat.rhel_system_roles
+    version: ">=1.23.0"
+  # windows
+  - name: ansible.windows
+    version: ">=2.3.0"
+  - name: chocolatey.chocolatey
+    version: ">=1.5.1"
+  - name: community.windows
+    version: ">=2.2.0"
+  # cloud
+  - name: amazon.aws
+    version: ">=7.5.0"
+  # satellite
+  - name: redhat.satellite
+    version: ">=4.0.0"
+  # network
+  - name: ansible.netcommon
+    version: ">=6.0.0"
+  - name: cisco.ios
+    version: ">=7.0.0"
+  - name: cisco.iosxr
+    version: ">=8.0.0"
+  - name: cisco.nxos
+    version: ">=7.0.0"
+  - name: infoblox.nios_modules
+    version: ">=1.6.1"
+  # openshift
+  - name: kubernetes.core
+    version: ">=4.0.0"
+  - name: redhat.openshift
+    version: ">=3.0.1"
+  - name: redhat.openshift_virtualization
+    version: ">=1.4.0"


### PR DESCRIPTION
currently we rely on EE images that are maintained in external repos, which requires coordination and time in order to make updates to our EE images.  this is an initial take on adding a local build process, which will allow us more granular control over any EE images we want to use with the demo content.  a complementary [quay.io organization](https://quay.io/organization/ansible-product-demos) has been set up for storing the images.  the build process is manual for now and described in the README.  if we like the idea of moving in this direction, over time we can look at a pipeline build process.

note that one of the requirements for using the redhat.openshift collection is adding the openshift-clients binary RPM to the EE.  adding the RPM to this repo works but it slows down git operations like cloning, so it may be worth moving to git-lfs for large file management.  using git-lfs would mean that developers need to install it locally, so we should probably discuss it before we move to that model.