### PR TITLE
Adding Automation Hub deployer with EE and repo sync

### DIFF
--- a/collections/ansible_collections/demo/openshift/roles/simple_ah/defaults/main.yml
+++ b/collections/ansible_collections/demo/openshift/roles/simple_ah/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+simple_ah_name: single-user-ah
+simple_ah_namespace: aap

--- a/collections/ansible_collections/demo/openshift/roles/simple_ah/tasks/main.yml
+++ b/collections/ansible_collections/demo/openshift/roles/simple_ah/tasks/main.yml
@@ -23,12 +23,13 @@
       delay: 30
 
     - name: Get automation_hub route hostname
-      ansible.builtin.set_fact:
-        automation_hub_hostname: "{{ r_ah_route.resources[0].spec.host }}"
+      ansible.builtin.set_stats:
+        data:
+          automation_hub_url: "https://{{ r_ah_route.resources[0].spec.host }}"
 
     - name: Display AH Instance URL
       ansible.builtin.debug:
         msg:
-          - "AH URL: https://{{ automation_hub_hostname }}"
+          - "AH URL: https://{{ r_ah_route.resources[0].spec.host }}"
           - "AH Admin Login: admin"
           - "AH Admin Password: <same as the Controller Admin password>"

--- a/collections/ansible_collections/demo/openshift/roles/simple_ah/tasks/main.yml
+++ b/collections/ansible_collections/demo/openshift/roles/simple_ah/tasks/main.yml
@@ -15,7 +15,7 @@
       kubernetes.core.k8s_info:
         api_version: "route.openshift.io/v1"
         kind: Route
-        name: hub
+        name: "{{ simple_ah_name }}"
         namespace: "{{ simple_ah_namespace }}"
       register: r_ah_route
       until: r_ah_route.resources[0].spec.host is defined

--- a/collections/ansible_collections/demo/openshift/roles/simple_ah/tasks/main.yml
+++ b/collections/ansible_collections/demo/openshift/roles/simple_ah/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+- name: Setup environment vars
+  block:
+    - name: Create Secret and Install AutomationHub
+      kubernetes.core.k8s:
+        state: present
+        definition: "{{ lookup('template', __definition) }}"
+      loop:
+        - admin_secret.yml.j2
+        - hub.yml.j2
+      loop_control:
+        loop_var: __definition
+
+    - name: Retrieve created hub route
+      kubernetes.core.k8s_info:
+        api_version: "route.openshift.io/v1"
+        kind: Route
+        name: hub
+        namespace: "{{ simple_ah_namespace }}"
+      register: r_ah_route
+      until: r_ah_route.resources[0].spec.host is defined
+      retries: 300
+      delay: 30
+
+    - name: Get automation_hub route hostname
+      ansible.builtin.set_fact:
+        automation_hub_hostname: "{{ r_ah_route.resources[0].spec.host }}"
+        automation_hub_admin_password: "{{ r_ah_secret.resources[0].data.password |string |b64decode }}"
+
+    - name: Display AH Instance URL
+      ansible.builtin.debug:
+        msg:
+          - "AH URL: https://{{ automation_hub_hostname }}"
+          - "AH Admin Login: admin"
+          - "AH Admin Password: <same as the Controller Admin password>"

--- a/collections/ansible_collections/demo/openshift/roles/simple_ah/tasks/main.yml
+++ b/collections/ansible_collections/demo/openshift/roles/simple_ah/tasks/main.yml
@@ -25,7 +25,6 @@
     - name: Get automation_hub route hostname
       ansible.builtin.set_fact:
         automation_hub_hostname: "{{ r_ah_route.resources[0].spec.host }}"
-        automation_hub_admin_password: "{{ r_ah_secret.resources[0].data.password |string |b64decode }}"
 
     - name: Display AH Instance URL
       ansible.builtin.debug:

--- a/collections/ansible_collections/demo/openshift/roles/simple_ah/tasks/main.yml
+++ b/collections/ansible_collections/demo/openshift/roles/simple_ah/tasks/main.yml
@@ -19,8 +19,8 @@
         namespace: "{{ simple_ah_namespace }}"
       register: r_ah_route
       until: r_ah_route.resources[0].spec.host is defined
-      retries: 300
-      delay: 30
+      retries: 120
+      delay: 2
 
     - name: Get automation_hub route hostname
       ansible.builtin.set_stats:

--- a/collections/ansible_collections/demo/openshift/roles/simple_ah/templates/admin_secret.yml.j2
+++ b/collections/ansible_collections/demo/openshift/roles/simple_ah/templates/admin_secret.yml.j2
@@ -7,9 +7,9 @@ metadata:
   labels:
     app.kubernetes.io/component: automationhub
     app.kubernetes.io/managed-by: automationhub-operator
-    app.kubernetes.io/name: {{ ah_insatnce_project_app_name }}
+    app.kubernetes.io/name: {{ simple_ah_name }}
     app.kubernetes.io/operator-version: '2.4'
-    app.kubernetes.io/part-of: {{ ah_instance_project_app_name }}
+    app.kubernetes.io/part-of: {{ simple_ah_name }}
 data:
   password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') | b64encode }}"
 type: Opaque

--- a/collections/ansible_collections/demo/openshift/roles/simple_ah/templates/admin_secret.yml.j2
+++ b/collections/ansible_collections/demo/openshift/roles/simple_ah/templates/admin_secret.yml.j2
@@ -1,0 +1,15 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ simple_ah_name }}-admin-password
+  namespace: {{ simple_ah_namespace }}
+  labels:
+    app.kubernetes.io/component: automationhub
+    app.kubernetes.io/managed-by: automationhub-operator
+    app.kubernetes.io/name: {{ ah_insatnce_project_app_name }}
+    app.kubernetes.io/operator-version: '2.4'
+    app.kubernetes.io/part-of: {{ ah_instance_project_app_name }}
+data:
+  password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') | b64encode }}"
+type: Opaque

--- a/collections/ansible_collections/demo/openshift/roles/simple_ah/templates/hub.yml.j2
+++ b/collections/ansible_collections/demo/openshift/roles/simple_ah/templates/hub.yml.j2
@@ -1,0 +1,51 @@
+---
+apiVersion: automationhub.ansible.com/v1beta1
+kind: AutomationHub
+metadata:
+  name: {{ simple_ah_name }}
+  namespace: {{ simple_ah_namespace }}
+spec:
+  nginx_proxy_send_timeout: 120s
+  gunicorn_content_workers: 2
+  gunicorn_api_workers: 2
+  route_tls_termination_mechanism: Edge
+  ingress_type: Route
+  loadbalancer_port: 80
+  no_log: true
+  file_storage_size: 100Gi
+  image_pull_policy: IfNotPresent
+  nginx_proxy_read_timeout: 120s
+  gunicorn_timeout: 90
+  nginx_client_max_body_size: 10m
+  web:
+    replicas: 1
+  nginx_proxy_connect_timeout: 120s
+  haproxy_timeout: 180s
+  file_storage_access_mode: ReadWriteOnce
+  content:
+    log_level: INFO
+    replicas: 2
+  postgres_storage_requirements:
+    limits:
+      storage: 50Gi
+    requests:
+      storage: 8Gi
+  api:
+    log_level: INFO
+    replicas: 1
+  postgres_resource_requirements:
+    limits:
+      cpu: 1000m
+      memory: 8Gi
+    requests:
+      cpu: 500m
+      memory: 2Gi
+  redis:
+    log_level: INFO
+    replicas: 1
+  loadbalancer_protocol: http
+  resource_manager:
+    replicas: 1
+  worker:
+    replicas: 2
+  admin_password_secret: {{ simple_ah_name }}-admin-password

--- a/openshift/hub/collections.yml
+++ b/openshift/hub/collections.yml
@@ -18,7 +18,7 @@
       infra.ah_configuration.collection_repository_sync:
         name: "{{ item.name }}"
         wait: true
-        timeout: 1500
+        timeout: 2500
         ah_host: "{{ automation_hub_url }}"
         ah_username: 'admin'
         ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"

--- a/openshift/hub/collections.yml
+++ b/openshift/hub/collections.yml
@@ -1,9 +1,9 @@
 ---
-- name: Add AH token to repo and Sync AutomationHub
+- name: Add AH collection token to repo and sync repository
   hosts: localhost
   gather_facts: false
   tasks:
-    - name: Add AH token
+    - name: Add Console AH token
       infra.ah_configuration.collection_remote:
         name: "{{ item.name }}"
         url: "{{ item.url }}"

--- a/openshift/hub/collections.yml
+++ b/openshift/hub/collections.yml
@@ -8,7 +8,7 @@
         name: "{{ item.name }}"
         url: "{{ item.url }}"
         auth_url: "{{ item.auth_url }}"
-        token: "{{ ah_token }}"
+        token: "{{ lookup('ansible.builtin.env', 'AH_TOKEN') }}"
         ah_host: "{{ automation_hub_url }}"
         ah_username: 'admin'
         ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"

--- a/openshift/hub/install.yml
+++ b/openshift/hub/install.yml
@@ -1,0 +1,8 @@
+---
+- name: Deploy simple Automation Hub instance
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Include role
+      ansible.builtin.include_role:
+        name: demo.openshift.simple_ah

--- a/openshift/hub/registries.yml
+++ b/openshift/hub/registries.yml
@@ -49,7 +49,7 @@
         ah_username: 'admin'
         ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
       loop: "{{ ah_ee_images }}"
-      retries: 50
+      retries: 120
       register: sync_image
       delay: 5
       until: sync_image is succeeded

--- a/openshift/hub/registries.yml
+++ b/openshift/hub/registries.yml
@@ -29,8 +29,6 @@
         name: "{{ item.name }}"
         state: present
         tags: "{{ item.tags }}"
-        wait: true
-        timeout: 300
         ah_host: "{{ automation_hub_url }}"
         ah_username: 'admin'
         ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"

--- a/openshift/hub/registries.yml
+++ b/openshift/hub/registries.yml
@@ -1,0 +1,37 @@
+---
+- name: Configure AH credential for registry and sync EEs
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Add Console EE credential
+      infra.ah_configuration.ah_ee_registry:
+        name: "{{ item.name }}"
+        url: "{{ item.url }}"
+        ah_host: "{{ automation_hub_url }}"
+        ah_username: 'admin'
+        ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
+        username: "{{ ee_registry_username }}"
+        password: "{{ ee_registry_password }}"
+      loop: "{{ ah_ee_registries }}"
+
+    - name: Sync AH registries
+      infra.ah_configuration.ah_ee_registry_sync:
+        name: "{{ item.name }}"
+        wait: true
+        timeout: 300
+        ah_host: "{{ automation_hub_url }}"
+        ah_username: 'admin'
+        ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
+      loop: "{{ ah_ee_registries }}"
+
+    - name: Pull EE images
+      infra.ah_configuration.ah_ee_image:
+        name: "{{ item.name }}"
+        state: present
+        tags: "{{ item.tags }}"
+        wait: true
+        timeout: 300
+        ah_host: "{{ automation_hub_url }}"
+        ah_username: 'admin'
+        ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
+      loop: "{{ ah_ee_images }}"

--- a/openshift/hub/registries.yml
+++ b/openshift/hub/registries.yml
@@ -49,7 +49,7 @@
         ah_username: 'admin'
         ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
       loop: "{{ ah_ee_images }}"
-      retries: 120
+      retries: 80
       register: sync_image
-      delay: 5
+      delay: 10
       until: sync_image is succeeded

--- a/openshift/hub/registries.yml
+++ b/openshift/hub/registries.yml
@@ -27,7 +27,7 @@
     - name: Index AH registries
       infra.ah_configuration.ah_ee_registry_index:
         name: "{{ item.name }}"
-        wait: true
+        wait: false
         timeout: 300
         ah_host: "{{ automation_hub_url }}"
         ah_username: 'admin'

--- a/openshift/hub/registries.yml
+++ b/openshift/hub/registries.yml
@@ -24,12 +24,12 @@
         ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
       loop: "{{ ah_ee_registries }}"
 
-    - name: Pull EE images
-      infra.ah_configuration.ah_ee_image:
+    - name: Index AH registries
+      infra.ah_configuration.ah_ee_registry_index:
         name: "{{ item.name }}"
-        state: present
-        tags: "{{ item.tags }}"
+        wait: true
+        timeout: 300
         ah_host: "{{ automation_hub_url }}"
         ah_username: 'admin'
         ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
-      loop: "{{ ah_ee_images }}"
+      loop: "{{ ah_ee_registries }}"

--- a/openshift/hub/registries.yml
+++ b/openshift/hub/registries.yml
@@ -3,6 +3,12 @@
   hosts: localhost
   gather_facts: false
   tasks:
+    - name: Assert non-default credentials
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.env', 'REGISTRY_USERNAME') != 'CHANGEME'
+        fail_msg: "Please provide `Usable Automation Hub Credential`"
+
     - name: Add Console EE credential
       infra.ah_configuration.ah_ee_registry:
         name: "{{ item.name }}"
@@ -10,12 +16,12 @@
         ah_host: "{{ automation_hub_url }}"
         ah_username: 'admin'
         ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
-        username: "{{ ee_registry_username }}"
-        password: "{{ ee_registry_password }}"
+        username: "{{ lookup('ansible.builtin.env', 'REGISTRY_USERNAME') }}"
+        password: "{{ lookup('ansible.builtin.env', 'REGISTRY_PASSWORD') }}"
       loop: "{{ ah_ee_registries }}"
 
-    - name: Sync AH registries
-      infra.ah_configuration.ah_ee_registry_sync:
+    - name: Index AH registries
+      infra.ah_configuration.ah_ee_registry_index:
         name: "{{ item.name }}"
         wait: true
         timeout: 300
@@ -24,12 +30,26 @@
         ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
       loop: "{{ ah_ee_registries }}"
 
-    - name: Index AH registries
-      infra.ah_configuration.ah_ee_registry_index:
+    # Not sure if this is a limitation of our AH deployment, or a bug,
+    # but the wait feature does not succeed, see the regries/until for 'Sync images'
+    - name: Sync AH registries
+      infra.ah_configuration.ah_ee_registry_sync:
         name: "{{ item.name }}"
         wait: false
-        timeout: 300
+        timeout: 1500
         ah_host: "{{ automation_hub_url }}"
         ah_username: 'admin'
         ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
       loop: "{{ ah_ee_registries }}"
+
+    - name: Sync images
+      infra.ah_configuration.ah_ee_image:
+        name: "{{ item.name }}"
+        ah_host: "{{ automation_hub_url }}"
+        ah_username: 'admin'
+        ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
+      loop: "{{ ah_ee_images }}"
+      retries: 50
+      register: sync_image
+      delay: 5
+      until: sync_image is succeeded

--- a/openshift/hub/sync.yml
+++ b/openshift/hub/sync.yml
@@ -1,0 +1,23 @@
+---
+- name: Add AH token to repo and Sync AutomationHub
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Add AH token
+      infra.ah_configuration.collection_remote:
+        name: rh-certified
+        token: "{{ ah_token }}"
+        url: https://console.redhat.com/api/automation-hub/content/published/
+        auth_url: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+        ah_host: "{{ automation_hub_url }}"
+        ah_username: 'admin'
+        ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
+
+    - name: Sync repositories in AH (this can take a while)
+      infra.ah_configuration.collection_repository_sync:
+        name: rh-certified
+        wait: true
+        timeout: 1500
+        ah_host: "{{ automation_hub_url }}"
+        ah_username: 'admin'
+        ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"

--- a/openshift/hub/sync.yml
+++ b/openshift/hub/sync.yml
@@ -5,19 +5,21 @@
   tasks:
     - name: Add AH token
       infra.ah_configuration.collection_remote:
-        name: rh-certified
+        name: "{{ item.name }}"
+        url: "{{ item.url }}"
+        auth_url: "{{ item.auth_url }}"
         token: "{{ ah_token }}"
-        url: https://console.redhat.com/api/automation-hub/content/published/
-        auth_url: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
         ah_host: "{{ automation_hub_url }}"
         ah_username: 'admin'
         ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
+      loop: "{{ ah_collection_remotes }}"
 
     - name: Sync repositories in AH (this can take a while)
       infra.ah_configuration.collection_repository_sync:
-        name: rh-certified
+        name: "{{ item.name }}"
         wait: true
         timeout: 1500
         ah_host: "{{ automation_hub_url }}"
         ah_username: 'admin'
         ah_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
+      loop: "{{ ah_collection_remotes }}"

--- a/openshift/setup.yml
+++ b/openshift/setup.yml
@@ -329,12 +329,13 @@ controller_workflows:
       - identifier: Install AH using AAP Operator
         unified_job_template: OpenShift / Hub / Install Automation Hub
         success_nodes:
-          - Sync Collections
           - Sync EEs
         failure_nodes:
           - Ticket - Instance Failed
       - identifier: Sync EEs
         unified_job_template: OpenShift / Hub / Sync EE Registries
+        success_nodes:
+          - Sync Collections
         failure_nodes:
           - Ticket - Instance Failed
       - identifier: Sync Collections

--- a/openshift/setup.yml
+++ b/openshift/setup.yml
@@ -53,11 +53,11 @@ controller_templates:
       - "OpenShift Credential"
       - "Controller Credential"
 
-  - name: OpenShift / Hub / Sync Repositories
+  - name: OpenShift / Hub / Sync Collection Repositories
     job_type: run
     inventory: "Demo Inventory"
     project: "Ansible official demo project"
-    playbook: "openshift/hub/sync.yml"
+    playbook: "openshift/hub/collections.yml"
     notification_templates_started: Telemetry
     notification_templates_success: Telemetry
     notification_templates_error: Telemetry
@@ -79,6 +79,41 @@ controller_templates:
           url: https://console.redhat.com/api/automation-hub/content/published/
           auth_url: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
 
+  - name: OpenShift / Hub / Sync EE Registries
+    job_type: run
+    inventory: "Demo Inventory"
+    project: "Ansible official demo project"
+    playbook: "openshift/hub/registries.yml"
+    notification_templates_started: Telemetry
+    notification_templates_success: Telemetry
+    notification_templates_error: Telemetry
+    survey_enabled: true
+    credentials:
+      - "OpenShift Credential"
+      - "Controller Credential"
+    survey:
+      name: ''
+      description: ''
+      spec:
+        - question_name: EE Registry username
+          type: text
+          variable: ee_registry_username
+          required: true
+        - question_name: EE Registry password
+          type: text
+          variable: ee_registry_password
+          required: true
+    extra_vars:
+      ah_ee_registries:
+        - name: rh-registry
+          url: https://registry.redhat.io
+      ah_ee_images:
+        - name: registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel9
+          tags:
+            - latest
+        - name: registry.redhat.io/ansible-automation-platform-24/ee-minimal-rhel9
+          tags:
+            - latest
 
   - name: OpenShift / CNV / Install Operator
     job_type: run
@@ -276,7 +311,7 @@ controller_workflows:
         extra_data:
           feedback: Failed to create CNV instance
 
-  - name: OpenShift / Hub / Deploy Automation Hub and sync repositories
+  - name: OpenShift / Hub / Deploy Automation Hub and sync EEs and Collections
     description: A workflow to deploy Automation Hub and sync repositories
     organization: Default
     notification_templates_started: Telemetry
@@ -291,15 +326,28 @@ controller_workflows:
           type: text
           variable: ah_token
           required: true
+        - question_name: EE Registry username
+          type: text
+          variable: ee_registry_username
+          required: true
+        - question_name: EE Registry password
+          type: text
+          variable: ee_registry_password
+          required: true
     simplified_workflow_nodes:
       - identifier: Install AH using AAP Operator
         unified_job_template: OpenShift / Hub / Install Automation Hub
         success_nodes:
-          - Sync Repos
+          - Sync Collections
+          - Sync EEs
         failure_nodes:
           - Ticket - Instance Failed
-      - identifier: Sync Repos
-        unified_job_template: OpenShift / Hub / Sync Repositories
+      - identifier: Sync EEs
+        unified_job_template: OpenShift / Hub / Sync EE Registries
+        failure_nodes:
+          - Ticket - Instance Failed
+      - identifier: Sync Collections
+        unified_job_template: OpenShift / Hub / Sync Collection Repositories
         failure_nodes:
           - Ticket - Instance Failed
       - identifier: Ticket - Instance Failed

--- a/openshift/setup.yml
+++ b/openshift/setup.yml
@@ -107,13 +107,6 @@ controller_templates:
       ah_ee_registries:
         - name: rh-registry
           url: https://registry.redhat.io
-      ah_ee_images:
-        - name: registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel9
-          tags:
-            - latest
-        - name: registry.redhat.io/ansible-automation-platform-24/ee-minimal-rhel9
-          tags:
-            - latest
 
   - name: OpenShift / CNV / Install Operator
     job_type: run

--- a/openshift/setup.yml
+++ b/openshift/setup.yml
@@ -40,7 +40,7 @@ controller_templates:
       - "OpenShift Credential"
       - "Controller Credential"
 
-  - name: OpenShift / Hub / Install Controller
+  - name: OpenShift / Hub / Install Automation Hub
     job_type: run
     inventory: "Demo Inventory"
     project: "Ansible official demo project"

--- a/openshift/setup.yml
+++ b/openshift/setup.yml
@@ -71,9 +71,14 @@ controller_templates:
       spec:
         - question_name: Automation Hub Token
           type: text
-          description: See https://console.redhat.com/ansible/automation-hub/token
           variable: ah_token
           required: true
+    extra_vars:
+      ah_collection_remotes:
+        - name: rh-certified
+          url: https://console.redhat.com/api/automation-hub/content/published/
+          auth_url: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
 
   - name: OpenShift / CNV / Install Operator
     job_type: run
@@ -270,3 +275,34 @@ controller_workflows:
         unified_job_template: 'SUBMIT FEEDBACK'
         extra_data:
           feedback: Failed to create CNV instance
+
+  - name: OpenShift / Hub / Deploy Automation Hub and sync repositories
+    description: A workflow to deploy Automation Hub and sync repositories
+    organization: Default
+    notification_templates_started: Telemetry
+    notification_templates_success: Telemetry
+    notification_templates_error: Telemetry
+    survey_enabled: true
+    survey:
+      name: ''
+      description: ''
+      spec:
+        - question_name: Automation Hub Token
+          type: text
+          variable: ah_token
+          required: true
+    simplified_workflow_nodes:
+      - identifier: Install AH using AAP Operator
+        unified_job_template: OpenShift / Hub / Install Automation Hub
+        success_nodes:
+          - Sync Repos
+        failure_nodes:
+          - Ticket - Instance Failed
+      - identifier: Sync Repos
+        unified_job_template: OpenShift / Hub / Sync Repositories
+        failure_nodes:
+          - Ticket - Instance Failed
+      - identifier: Ticket - Instance Failed
+        unified_job_template: 'SUBMIT FEEDBACK'
+        extra_data:
+          feedback: Failed to deploy Automation Hub on OCP

--- a/openshift/setup.yml
+++ b/openshift/setup.yml
@@ -40,6 +40,19 @@ controller_templates:
       - "OpenShift Credential"
       - "Controller Credential"
 
+  - name: OpenShift / Hub / Install Controller
+    job_type: run
+    inventory: "Demo Inventory"
+    project: "Ansible official demo project"
+    playbook: "openshift/hub/install.yml"
+    notification_templates_started: Telemetry
+    notification_templates_success: Telemetry
+    notification_templates_error: Telemetry
+    survey_enabled: true
+    credentials:
+      - "OpenShift Credential"
+      - "Controller Credential"
+
   - name: OpenShift / CNV / Install Operator
     job_type: run
     inventory: "Demo Inventory"

--- a/openshift/setup.yml
+++ b/openshift/setup.yml
@@ -53,6 +53,28 @@ controller_templates:
       - "OpenShift Credential"
       - "Controller Credential"
 
+  - name: OpenShift / Hub / Sync Repositories
+    job_type: run
+    inventory: "Demo Inventory"
+    project: "Ansible official demo project"
+    playbook: "openshift/hub/sync.yml"
+    notification_templates_started: Telemetry
+    notification_templates_success: Telemetry
+    notification_templates_error: Telemetry
+    survey_enabled: true
+    credentials:
+      - "OpenShift Credential"
+      - "Controller Credential"
+    survey:
+      name: ''
+      description: ''
+      spec:
+        - question_name: Automation Hub Token
+          type: text
+          description: See https://console.redhat.com/ansible/automation-hub/token
+          variable: ah_token
+          required: true
+
   - name: OpenShift / CNV / Install Operator
     job_type: run
     inventory: "Demo Inventory"

--- a/openshift/setup.yml
+++ b/openshift/setup.yml
@@ -7,7 +7,39 @@ controller_components:
   - job_templates
   - workflow_job_templates
 
+controller_credential_types:
+  - name: Usable Automation Hub Credential
+    kind: cloud
+    description: A credential we can use from a playbook to interact with Automation Hub
+    inputs:
+      fields:
+        - id: registry_username
+          type: string
+          label: Registry Username
+        - id: registry_password
+          type: string
+          label: Registry Password
+          secret: true
+        - id: ah_token
+          type: string
+          label: Automation Hub Token
+          secret: true
+    injectors:
+      env:
+        REGISTRY_USERNAME: !unsafe '{{ registry_username }}'
+        REGISTRY_PASSWORD: !unsafe '{{ registry_password }}'
+        AH_TOKEN: !unsafe '{{ ah_token }}'
+
 controller_credentials:
+  - name: Usable Hub Credential
+    organization: Default
+    credential_type: Usable Automation Hub Credential
+    state: exists
+    inputs:
+      registry_username: CHANGEME
+      registry_password: CHANGEME
+      ah_token: CHANGEME
+
   - name: OpenShift Credential
     organization: Default
     credential_type: OpenShift or Kubernetes API Bearer Token
@@ -63,16 +95,8 @@ controller_templates:
     notification_templates_error: Telemetry
     survey_enabled: true
     credentials:
-      - "OpenShift Credential"
       - "Controller Credential"
-    survey:
-      name: ''
-      description: ''
-      spec:
-        - question_name: Automation Hub Token
-          type: text
-          variable: ah_token
-          required: true
+      - "Usable Hub Credential"
     extra_vars:
       ah_collection_remotes:
         - name: rh-certified
@@ -89,24 +113,14 @@ controller_templates:
     notification_templates_error: Telemetry
     survey_enabled: true
     credentials:
-      - "OpenShift Credential"
       - "Controller Credential"
-    survey:
-      name: ''
-      description: ''
-      spec:
-        - question_name: EE Registry username
-          type: text
-          variable: ee_registry_username
-          required: true
-        - question_name: EE Registry password
-          type: text
-          variable: ee_registry_password
-          required: true
+      - "Usable Hub Credential"
     extra_vars:
       ah_ee_registries:
         - name: rh-registry
           url: https://registry.redhat.io
+      ah_ee_images:
+        - name: "ansible-automation-platform-24/ee-supported-rhel9"
 
   - name: OpenShift / CNV / Install Operator
     job_type: run
@@ -311,22 +325,6 @@ controller_workflows:
     notification_templates_success: Telemetry
     notification_templates_error: Telemetry
     survey_enabled: true
-    survey:
-      name: ''
-      description: ''
-      spec:
-        - question_name: Automation Hub Token
-          type: text
-          variable: ah_token
-          required: true
-        - question_name: EE Registry username
-          type: text
-          variable: ee_registry_username
-          required: true
-        - question_name: EE Registry password
-          type: text
-          variable: ee_registry_password
-          required: true
     simplified_workflow_nodes:
       - identifier: Install AH using AAP Operator
         unified_job_template: OpenShift / Hub / Install Automation Hub


### PR DESCRIPTION
This PR includes job templates to deploy an Automation Hub instance via the OpenShift operator, synchronize EE registries, and galaxy collections, and a workflow chaining them together. I created a custom credential type, `Usable Automation Hub Credential` since we aren't unable to use the built-in credential type within a playbook. This credential needs to be filled out by the user before running the relevant jobs.

A distinguishing feature is that we use `ReadWriteOnce` for the underlying PV (see [OCP access modes](https://docs.openshift.com/container-platform/4.16/storage/understanding-persistent-storage.html#pv-access-modes_understanding-persistent-storage) ) as opposed to the recommended `ReadWriteMany`. Thus this should not be used for production system.

It's also noteworthy that due to syncing ~2100 collections in the `rh-certified` repo and roughly 70GB of storage they occupy, the workflow takes ~30 minutes to run.

This PR is a stepping stone to ultimately being able to have a relatively simple job within APD that builds a custom EE.