### PR TITLE
added local build script for product demos EEs

### DIFF
--- a/execution_environments/.gitattributes
+++ b/execution_environments/.gitattributes
@@ -1,0 +1,1 @@
+openshift-clients-4.16.0-202408021139.p0.ge8fb3c0.assembly.stream.el9.x86_64.rpm filter=lfs diff=lfs merge=lfs -text

--- a/execution_environments/README.md
+++ b/execution_environments/README.md
@@ -1,0 +1,14 @@
+# Execution Environment Images for Ansible Product Demos
+
+When the Ansible Product Demos setup job template is run, it creates a number of execution environment definitions on the automation controller.  The content of this directory is used to create and update the default execution environment images defined during the setup process.
+
+Currently these execution environment images are created manually using the `build.sh` script, with a future goal of building in a CI pipeline when any EE definitions or requirements are updated.
+
+## Building the execution environment images
+
+1. `podman login registry.redhat.io` in order to pull the base EE images
+2. `./build.sh` to build the EE images and add them to your local podman image cache
+
+The `build.sh` script creates multiple EE images, each based on the ee-minimal image that comes with a different minor version of AAP.  These images are created in the "quay.io/ansible-product-demos" namespace.  Currently the script builds the following images:
+
+* quay.io/ansible-product-demos/apd-ee-24

--- a/execution_environments/ansible.cfg
+++ b/execution_environments/ansible.cfg
@@ -1,0 +1,15 @@
+[defaults]
+
+[galaxy]
+server_list = certified, validated, community_galaxy
+
+[galaxy_server.certified]
+url=https://cloud.redhat.com/api/automation-hub/content/published/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+[galaxy_server.validated]
+url=https://cloud.redhat.com/api/automation-hub/content/validated/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+[galaxy_server.community_galaxy]
+url=https://galaxy.ansible.com/

--- a/execution_environments/apd-ee-24.yml
+++ b/execution_environments/apd-ee-24.yml
@@ -1,0 +1,32 @@
+---
+version: 3
+images:
+  base_image:
+    name: registry.redhat.io/ansible-automation-platform-24/ee-minimal-rhel9:latest
+
+dependencies:
+  galaxy: requirements.yml
+
+additional_build_files:
+  # https://access.redhat.com/solutions/7024259
+  # download from access.redhat.com -> Downloads -> OpenShift Container Platform -> Packages
+  - src: openshift-clients-4.16.0-202408021139.p0.ge8fb3c0.assembly.stream.el9.x86_64.rpm
+    dest: rpms
+  - src: ansible.cfg
+    dest: configs
+
+options:
+  package_manager_path: /usr/bin/microdnf
+
+additional_build_steps:
+  prepend_base:
+    - RUN $PYCMD -m pip install --upgrade pip setuptools
+    - COPY _build/rpms/openshift-clients*.rpm /tmp/openshift-clients.rpm
+    - RUN $PKGMGR -y update && $PKGMGR -y install bash-completion && $PKGMGR clean all
+    - RUN rpm -ivh /tmp/openshift-clients.rpm && rm /tmp/openshift-clients.rpm
+  prepend_galaxy:
+    - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+    - ARG ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN
+    - ARG ANSIBLE_GALAXY_SERVER_VALIDATED_TOKEN
+
+...

--- a/execution_environments/apd-ee-25.yml
+++ b/execution_environments/apd-ee-25.yml
@@ -1,0 +1,32 @@
+---
+version: 3
+images:
+  base_image:
+    name: registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel9:latest
+
+dependencies:
+  galaxy: requirements.yml
+
+additional_build_files:
+  # https://access.redhat.com/solutions/7024259
+  # download from access.redhat.com -> Downloads -> OpenShift Container Platform -> Packages
+  - src: openshift-clients-4.16.0-202408021139.p0.ge8fb3c0.assembly.stream.el9.x86_64.rpm
+    dest: rpms
+  - src: ansible.cfg
+    dest: configs
+
+options:
+  package_manager_path: /usr/bin/microdnf
+
+additional_build_steps:
+  prepend_base:
+    - RUN $PYCMD -m pip install --upgrade pip setuptools
+    - COPY _build/rpms/openshift-clients*.rpm /tmp/openshift-clients.rpm
+    - RUN $PKGMGR -y update && $PKGMGR -y install bash-completion && $PKGMGR clean all
+    - RUN rpm -ivh /tmp/openshift-clients.rpm && rm /tmp/openshift-clients.rpm
+  prepend_galaxy:
+    - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+    - ARG ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN
+    - ARG ANSIBLE_GALAXY_SERVER_VALIDATED_TOKEN
+
+...

--- a/execution_environments/build.sh
+++ b/execution_environments/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# array of images to build
+ee_images=(
+    "apd-ee-24"
+)
+
+for ee in "${ee_images[@]}"
+do
+    # build EE image
+    ansible-builder build \
+        --file ${ee}.yml \
+        --context ./ee_contexts/${ee} \
+        --build-arg ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN \
+        --build-arg ANSIBLE_GALAXY_SERVER_VALIDATED_TOKEN \
+        -v 3 \
+        -t quay.io/ansible-product-demos/${ee}:$(date +%Y%m%d)
+
+    if [[ $? == 0 ]]
+    then
+        # tag EE image as latest
+        podman tag \
+            quay.io/ansible-product-demos/${ee}:$(date +%Y%m%d) \
+            quay.io/ansible-product-demos/${ee}:latest
+    fi
+done

--- a/execution_environments/openshift-clients-4.16.0-202408021139.p0.ge8fb3c0.assembly.stream.el9.x86_64.rpm
+++ b/execution_environments/openshift-clients-4.16.0-202408021139.p0.ge8fb3c0.assembly.stream.el9.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f637eb0440f14f1458800c7a9012adcb9b58eb2131c02f64dfa4ca515e182093
+size 54960859

--- a/execution_environments/requirements.yml
+++ b/execution_environments/requirements.yml
@@ -1,0 +1,52 @@
+---
+collections:
+  - name: ansible.controller
+    version: ">=4.5.5"
+  - name: infra.ah_configuration
+    version: ">=2.0.6"
+  - name: infra.controller_configuration
+    version: ">=2.9.0"
+  - name: redhat_cop.controller_configuration
+    version: ">=2.3.1"
+  # linux
+  - name: ansible.posix
+    version: ">=1.5.4"
+  - name: community.general
+    version: ">=8.0.0"
+  - name: containers.podman
+    version: ">=1.12.1"
+  - name: redhat.insights
+    version: ">=1.2.2"
+  - name: redhat.rhel_system_roles
+    version: ">=1.23.0"
+  # windows
+  - name: ansible.windows
+    version: ">=2.3.0"
+  - name: chocolatey.chocolatey
+    version: ">=1.5.1"
+  - name: community.windows
+    version: ">=2.2.0"
+  # cloud
+  - name: amazon.aws
+    version: ">=7.5.0"
+  # satellite
+  - name: redhat.satellite
+    version: ">=4.0.0"
+  # network
+  - name: ansible.netcommon
+    version: ">=6.0.0"
+  - name: cisco.ios
+    version: ">=7.0.0"
+  - name: cisco.iosxr
+    version: ">=8.0.0"
+  - name: cisco.nxos
+    version: ">=7.0.0"
+  - name: infoblox.nios_modules
+    version: ">=1.6.1"
+  # openshift
+  - name: kubernetes.core
+    version: ">=4.0.0"
+  - name: redhat.openshift
+    version: ">=3.0.1"
+  - name: redhat.openshift_virtualization
+    version: ">=1.4.0"


### PR DESCRIPTION
a simple method for building new product demos EE imagess without relying on an external repo and build process.  the EE images would be tagged and pushed to a new container repository namespace.  this PR only introduces the build process; a separate PR would be needed to convert product demos over to the new EE image(s).  a future goal would be creating a build pipeline so that changes to the EE can be built and pushed automatically.

this PR also introduces the ability to build and tag multiple EE images based on AAP versions, which should meet the requirements for #115.

note that this commit uses [git-lfs](https://docs.github.com/en/repositories/working-with-files/managing-large-files/configuring-git-large-file-storage) for managing the openshift-clients binary RPM.  anyone who needs to update the RPM version will need to [install git-lfs](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage) in their local copy of the repo (git-lfs is also available as an RPM in the RHEL 9 AppStream repo).