### PR TITLE
Specify Windows image owner to prevent licensing error

### DIFF
--- a/windows/setup.yml
+++ b/windows/setup.yml
@@ -360,6 +360,9 @@ controller_workflows:
     notification_templates_started: Telemetry
     notification_templates_success: Telemetry
     notification_templates_error: Telemetry
+    extra_vars:
+      create_vm_aws_image_owners:
+        - amazon
     survey_enabled: true
     survey:
       name: ''


### PR DESCRIPTION
Addresses issue #186 

Pin the AMI search to those owned by the amazon owner alias to prevent errors during provisioning. Once this [PR](https://github.com/ansible-content-lab/aws.infrastructure_config_demos/pull/20) to aws.infrastructure_config_demos is merged, this change could be reverted.