### PR TITLE
Upgade pywinrm to fix Windows workloads for AAP 2.5 EE running Python 3.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ choose_demo_example_aws.yml
 roles/*
 !roles/requirements.yml
 .deployment_id
+.cache/
+.ansible/

--- a/common/setup.yml
+++ b/common/setup.yml
@@ -71,6 +71,8 @@ controller_groups:
     variables:
       ansible_connection: winrm
       ansible_winrm_transport: credssp
+      ansible_winrm_server_cert_validation: ignore
+      ansible_port: 5986
 
 controller_templates:
   - name: SUBMIT FEEDBACK

--- a/execution_environments/README.md
+++ b/execution_environments/README.md
@@ -6,9 +6,14 @@ Currently these execution environment images are created manually using the `bui
 
 ## Building the execution environment images
 
-1. `podman login registry.redhat.io` in order to pull the base EE images
-2. `./build.sh` to build the EE images and add them to your local podman image cache
+1. Download the [openshift-clients rpm](https://access.redhat.com/downloads/content/rhel---9/x86_64/20821/openshift-clients/4.16.0-202408021139.p0.ge8fb3c0.assembly.stream.el9/x86_64/fd431d51/package)
+2. Overwrite existing link to git-lfs by copying downloaded RPM to `<repo-root>/execution-environments/openshift-clients-4.16.0-202408021139.p0.ge8fb3c0.assembly.stream.el9.x86_64.rpm`
+3. `podman login registry.redhat.io` in order to pull the base EE images
+4. `export ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN="<token>"` obtained from [Automation Hub](https://console.redhat.com/ansible/automation-hub/token)
+5. `export ANSIBLE_GALAXY_SERVER_VALIDATED_TOKEN="<token>"` (same as above)
+6. `./build.sh` to build the EE images and add them to your local podman image cache
 
 The `build.sh` script creates multiple EE images, each based on the ee-minimal image that comes with a different minor version of AAP.  These images are created in the "quay.io/ansible-product-demos" namespace.  Currently the script builds the following images:
 
 * quay.io/ansible-product-demos/apd-ee-24
+* quay.io/ansible-product-demos/apd-ee-25

--- a/execution_environments/README.md
+++ b/execution_environments/README.md
@@ -6,12 +6,10 @@ Currently these execution environment images are created manually using the `bui
 
 ## Building the execution environment images
 
-1. Download the [openshift-clients rpm](https://access.redhat.com/downloads/content/rhel---9/x86_64/20821/openshift-clients/4.16.0-202408021139.p0.ge8fb3c0.assembly.stream.el9/x86_64/fd431d51/package)
-2. Overwrite existing link to git-lfs by copying downloaded RPM to `<repo-root>/execution-environments/openshift-clients-4.16.0-202408021139.p0.ge8fb3c0.assembly.stream.el9.x86_64.rpm`
-3. `podman login registry.redhat.io` in order to pull the base EE images
-4. `export ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN="<token>"` obtained from [Automation Hub](https://console.redhat.com/ansible/automation-hub/token)
-5. `export ANSIBLE_GALAXY_SERVER_VALIDATED_TOKEN="<token>"` (same as above)
-6. `./build.sh` to build the EE images and add them to your local podman image cache
+1. `podman login registry.redhat.io` in order to pull the base EE images
+2. `export ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN="<token>"` obtained from [Automation Hub](https://console.redhat.com/ansible/automation-hub/token)
+3. `export ANSIBLE_GALAXY_SERVER_VALIDATED_TOKEN="<token>"` (same as above)
+4. `./build.sh` to build the EE images and add them to your local podman image cache
 
 The `build.sh` script creates multiple EE images, each based on the ee-minimal image that comes with a different minor version of AAP.  These images are created in the "quay.io/ansible-product-demos" namespace.  Currently the script builds the following images:
 

--- a/execution_environments/apd-ee-25.yml
+++ b/execution_environments/apd-ee-25.yml
@@ -6,6 +6,8 @@ images:
 
 dependencies:
   galaxy: requirements-25.yml
+  python:
+    - pywinrm>=0.4.3
   python_interpreter:
     python_path: /usr/bin/python3.11
 

--- a/windows/group_vars/os_windows.yml
+++ b/windows/group_vars/os_windows.yml
@@ -1,5 +1,0 @@
----
-ansible_connection: winrm
-ansible_winrm_transport: ntlm
-ansible_winrm_server_cert_validation: ignore
-ansible_port: 5986

--- a/windows/setup.yml
+++ b/windows/setup.yml
@@ -474,7 +474,7 @@ controller_workflows:
         job_type: run
         extra_data:
           _hosts: purpose_domain_computer
-          domain_controller: dc01.ansible.local
+          domain_controller: dc01
         failure_nodes:
           - Cleanup Resources
         success_nodes:

--- a/windows/setup.yml
+++ b/windows/setup.yml
@@ -420,7 +420,7 @@ controller_workflows:
         unified_job_template: Cloud / AWS / Create VM
         job_type: run
         extra_data:
-          create_vm_vm_name: dc01.ansible.local
+          create_vm_vm_name: dc01
           create_vm_vm_purpose: domain_controller
           create_vm_vm_deployment: domain_ansible_local
           vm_blueprint: windows_full
@@ -430,7 +430,7 @@ controller_workflows:
         unified_job_template: Cloud / AWS / Create VM
         job_type: run
         extra_data:
-          create_vm_vm_name: winston.ansible.local
+          create_vm_vm_name: winston
           create_vm_vm_purpose: domain_computer
           create_vm_vm_deployment: domain_ansible_local
           vm_blueprint: windows_core
@@ -440,7 +440,7 @@ controller_workflows:
         unified_job_template: Cloud / AWS / Create VM
         job_type: run
         extra_data:
-          create_vm_vm_name: winthrop.ansible.local
+          create_vm_vm_name: winthrop
           create_vm_vm_purpose: domain_computer
           create_vm_vm_deployment: domain_ansible_local
           vm_blueprint: windows_core


### PR DESCRIPTION
Related to issue:
#205 

- update apd-ee-25 pywinrm and consolidate os_windows group_vars
- updated ee build docs

Succesfull run using newly built [execution-environment](https://quay.io/repository/zleblanc/apd-ee-25?tab=tags):
![Screenshot 2024-12-13 at 11 55 12 AM](https://github.com/user-attachments/assets/49208df7-99d6-44c9-ba7d-bf1963b9b7c8)
