### PR TITLE
Added NETWORK / Backups to show using validated content to back up network devices

### DIFF
--- a/network/README.md
+++ b/network/README.md
@@ -12,6 +12,8 @@
 This category of demos shows examples of network operations and management with Ansible Automation Platform. The list of demos can be found below. See the [Suggested Usage](#suggested-usage) section of this document for recommendations on how to best use these demos.
 - [**NETWORK / Configuration**](https://github.com/nleiva/ansible-net-modules/blob/main/main.yml) - Deploy golden configurations for different resources to Cisco IOS, IOSXR, and NXOS.
 
+To run the demos, deploy them using Infrastructure as Code, run either the "Product Demos | Multi-demo setup" or the "Product Demos | Single demo setup" and select 'Network' in the "Product Demos" deployment, or utilize the steps in the repo level README.
+
 ### Project
 
 These demos leverage playbooks from a [git repo](https://github.com/nleiva/ansible-net-modules) that is added as the **`Network Golden Configs`** Project in your Ansible Controller. Review this repo for the playbooks to configure different resources and network config templates that will be configured.
@@ -77,3 +79,9 @@ A **`Demo Inventory`** is created when setting up these demos and a dynamic sour
   },
   "_ansible_no_log": false
 }
+
+**NETWORK / BACKUP** - Use this job to show how Ansible can be used to backup network devices. Job Template will create a backup file on the reports server where they can be viewed.  This is just an example - backups can also be sent to other repositories such as a Git repo (Github, Gitlab, etc).
+
+To run this demo, you will need to complete a couple of prerequisites:
+- Run the "Deploy Cloud Stack in AWS" job template.  This will create (among other things) a reports server.
+- You may need to update the "Demo Credential".

--- a/network/README.md
+++ b/network/README.md
@@ -83,5 +83,6 @@ A **`Demo Inventory`** is created when setting up these demos and a dynamic sour
 **NETWORK / BACKUP** - Use this job to show how Ansible can be used to backup network devices. Job Template will create a backup file on the reports server where they can be viewed.  This is just an example - backups can also be sent to other repositories such as a Git repo (Github, Gitlab, etc).
 
 To run this demo, you will need to complete a couple of prerequisites:
-- Run the "Deploy Cloud Stack in AWS" job template.  This will create (among other things) a reports server.
-- You may need to update the "Demo Credential".
+- Run the "Deploy Cloud Stack in AWS" job template.  This will create (among other things) a reports server.  You will want to use the public key from the "Product Demos" page.
+- You may need to update the "Demo Credential"; the latest product demos for 2.5 did not require this when
+using the public key from the "Product Demos" deployment page.

--- a/network/backup.yml
+++ b/network/backup.yml
@@ -2,8 +2,6 @@
 - name: Create network reports server
   hosts: reports
   become: true
-  vars:
-    backup_path: /var/www/html/backups
 
   tasks:
     - name: Build report server
@@ -15,7 +13,7 @@
     - name: Create a backup directory if it does not exist
       run_once: true
       ansible.builtin.file:
-        path: "{{ backup_path }}"
+        path: "/var/www/html/backups"
         state: directory
         owner: ec2-user
         group: ec2-user
@@ -26,7 +24,6 @@
   gather_facts: false
   vars:
     report_server: reports
-    backup_path: /var/www/html/backups
     backup_dir: "/tmp/network_backups"
 
   tasks:
@@ -51,7 +48,7 @@
       delegate_to: "{{ report_server }}"
       ansible.builtin.copy:
         src: "{{ backup_dir }}/{{ inventory_hostname }}.txt"
-        dest: "{{ backup_path }}/{{ inventory_hostname }}.cfg"
+        dest: "/var/www/html/backups/{{ inventory_hostname }}.cfg"
         backup: true
         owner: ec2-user
         group: ec2-user

--- a/network/backup.yml
+++ b/network/backup.yml
@@ -21,7 +21,7 @@
         group: ec2-user
         mode: '0755'
 
-- name: Backup Devices
+- name: Play to Backup Cisco Always-On Network Devices
   hosts: routers
   gather_facts: false
   vars:
@@ -30,7 +30,6 @@
     backup_dir: "/tmp/network_backups"
 
   tasks:
-
     - name: Network Backup and Resource Manager
       ansible.builtin.include_role:
         name: network.backup.run
@@ -62,7 +61,6 @@
       delegate_to: "{{ report_server }}"
       run_once: true
       ansible.builtin.debug:
-        msg: "Go to http://{{ ansible_host }}/backups/"
-      
-...
+        msg: "To review backed up configurations, go to http://{{ ansible_host }}/backups/"
 
+...

--- a/network/backup.yml
+++ b/network/backup.yml
@@ -1,0 +1,68 @@
+---
+- name: Create network reports server
+  hosts: reports
+  become: true
+  vars:
+    backup_path: /var/www/html/backups
+
+  tasks:
+    - name: Build report server
+      ansible.builtin.include_role:
+        name: "{{ item }}"
+      loop:
+        - demo.patching.report_server
+
+    - name: Create a backup directory if it does not exist
+      run_once: true
+      ansible.builtin.file:
+        path: "{{ backup_path }}"
+        state: directory
+        owner: ec2-user
+        group: ec2-user
+        mode: '0755'
+
+- name: Backup Devices
+  hosts: routers
+  gather_facts: false
+  vars:
+    report_server: reports
+    backup_path: /var/www/html/backups
+    backup_dir: "/tmp/network_backups"
+
+  tasks:
+
+    - name: Network Backup and Resource Manager
+      ansible.builtin.include_role:
+        name: network.backup.run
+      vars:
+        operation: backup
+        type: full
+        data_store:
+          local: "{{ backup_dir }}"
+
+    # This task removes the Current configuration... from the top of IOS routers show run
+    - name: Remove non config lines - regexp
+      delegate_to: localhost
+      ansible.builtin.lineinfile:
+        path: "{{ backup_dir }}/{{ inventory_hostname }}.txt"
+        line: "Building configuration..."
+        state: absent
+
+    - name: Copy backup file
+      delegate_to: "{{ report_server }}"
+      ansible.builtin.copy:
+        src: "{{ backup_dir }}/{{ inventory_hostname }}.txt"
+        dest: "{{ backup_path }}/{{ inventory_hostname }}.cfg"
+        backup: true
+        owner: ec2-user
+        group: ec2-user
+        mode: '0644'
+
+    - name: Review backs on report server
+      delegate_to: "{{ report_server }}"
+      run_once: true
+      ansible.builtin.debug:
+        msg: "Go to http://{{ ansible_host }}/backups/"
+      
+...
+

--- a/network/backup.yml
+++ b/network/backup.yml
@@ -57,7 +57,7 @@
         group: ec2-user
         mode: '0644'
 
-    - name: Review backs on report server
+    - name: Review backup on report server
       delegate_to: "{{ report_server }}"
       run_once: true
       ansible.builtin.debug:

--- a/network/setup.yml
+++ b/network/setup.yml
@@ -119,4 +119,3 @@ controller_templates:
     notification_templates_started: Telemetry
     notification_templates_success: Telemetry
     notification_templates_error: Telemetry
-    use_fact_cache: true

--- a/network/setup.yml
+++ b/network/setup.yml
@@ -11,7 +11,9 @@ controller_projects:
     scm_type: git
     scm_url: https://github.com/nleiva/ansible-net-modules
     update_project: true
-    wait: true
+    wait: false
+    controller_request_timeout: 20
+    controller_configuration_async_retries: 40
     default_environment: Networking Execution Environment
 
 controller_inventories:
@@ -33,6 +35,8 @@ controller_templates:
     survey_enabled: true
     project: Network Golden Configs
     playbook: main.yml
+    credentials:
+      - "Demo Credential"
     execution_environment: Networking Execution Environment
     notification_templates_started: Telemetry
     notification_templates_success: Telemetry
@@ -95,9 +99,24 @@ controller_templates:
     inventory: Demo Inventory
     project: "Ansible Product Demos"
     playbook: "network/compliance.yml"
+    credentials:
+      - "Demo Credential"
     notification_templates_started: Telemetry
     notification_templates_success: Telemetry
     notification_templates_error: Telemetry
     use_fact_cache: true
     ask_job_type_on_launch: true
     survey_enabled: true
+
+  - name: "NETWORK / Backup"
+    job_type: run
+    organization: Default
+    inventory: Demo Inventory
+    project: "Ansible Product Demos"
+    playbook: "network/backup.yml"
+    credentials:
+      - "Demo Credential"
+    notification_templates_started: Telemetry
+    notification_templates_success: Telemetry
+    notification_templates_error: Telemetry
+    use_fact_cache: true


### PR DESCRIPTION
Closes 182

Adds a playbook to backup the Cisco always-on systems using Red Hat validate content.  More work can be done after the merge to also backup multi-vendor.

Includes updates to setup for Product Demos.

Tested against Product Demos 2.5

Requires quay.io/ansible-product-demos/apd-ee-25:20241219 built by JCE #211 - this has been linked to lastest as of 01/06/25.