### PR TITLE
Rename Windows ec2 instance for #235

### DIFF
--- a/cloud/setup.yml
+++ b/cloud/setup.yml
@@ -283,7 +283,7 @@ controller_workflows:
       - identifier: Deploy Windows GUI Blueprint
         unified_job_template: Cloud / AWS / Create VM
         extra_data:
-          create_vm_vm_name: aws_dc
+          create_vm_vm_name: aws-dc
           vm_blueprint: windows_full
         success_nodes:
           - Update Inventory

--- a/execution_environments/apd-ee-25.yml
+++ b/execution_environments/apd-ee-25.yml
@@ -3,9 +3,10 @@ version: 3
 images:
   base_image:
     name: registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel9:latest
-
 dependencies:
   galaxy: requirements-25.yml
+  system:
+    - python3.11-devel [platform:rpm]
   python:
     - pywinrm>=0.4.3
   python_interpreter:

--- a/execution_environments/requirements-25.yml
+++ b/execution_environments/requirements-25.yml
@@ -27,6 +27,8 @@ collections:
   - name: redhat.rhel_system_roles
     version: ">=1.23.0"
   # windows demos
+  - name: microsoft.ad
+    version: "1.9"
   - name: ansible.windows
     version: ">=2.3.0"
   - name: chocolatey.chocolatey

--- a/execution_environments/requirements.yml
+++ b/execution_environments/requirements.yml
@@ -20,6 +20,8 @@ collections:
   - name: redhat.rhel_system_roles
     version: ">=1.23.0"
   # windows
+  - name: microsoft.ad
+    version: "1.9"
   - name: ansible.windows
     version: ">=2.3.0"
   - name: chocolatey.chocolatey

--- a/windows/create_ad_domain.yml
+++ b/windows/create_ad_domain.yml
@@ -22,7 +22,7 @@
 
     - name: Create new domain in a new forest on the target host
       register: r_create_domain
-      ansible.windows.win_domain:
+      microsoft.ad.domain:
         dns_domain_name: ansible.local
         safe_mode_password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1) }}"
 
@@ -33,7 +33,7 @@
         file: tasks/domain_services_check.yml
 
     - name: Create some groups
-      community.windows.win_domain_group:
+      microsoft.ad.group:
         name: "{{ item.name }}"
         scope: global
       loop:
@@ -44,7 +44,7 @@
       delay: 10
 
     - name: Create some users
-      community.windows.win_domain_user:
+      microsoft.ad.user:
         name: "{{ item.name }}"
         groups: "{{ item.groups }}"
         password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1) }}"

--- a/windows/create_ad_domain.yml
+++ b/windows/create_ad_domain.yml
@@ -12,8 +12,11 @@
     - name: Update the hostname
       ansible.windows.win_hostname:
         name: "{{ inventory_hostname.split('.')[0] }}"
+      register: r_rename_hostname
 
     - name: Reboot to apply new hostname
+      # noqa no-handler
+      when: r_rename_hostname is changed
       ansible.windows.win_reboot:
         reboot_timeout: 3600
 


### PR DESCRIPTION
Fairly straight-forward changes to rename the default Infra Stack `win_dc` to `win-dc` in order to make the AD / Create Domain JT work without having to re-name the ec2 instance, see #235. Also went ahead and updated the modules used to get rid of deprecation warnings.