### PR TITLE
Attempt to fix race condition with CNV hosts

### DIFF
--- a/openshift/setup.yml
+++ b/openshift/setup.yml
@@ -270,7 +270,7 @@ controller_workflows:
         unified_job_template: OpenShift / CNV / Wait Hosts
         failure_nodes:
           - Inventory Sync
-    - identifier: Inventory Sync
+      - identifier: Inventory Sync
         unified_job_template: OpenShift CNV Inventory
 
   - name: OpenShift / CNV / Infra Stack

--- a/openshift/setup.yml
+++ b/openshift/setup.yml
@@ -269,8 +269,8 @@ controller_workflows:
       - identifier: Wait Hosts
         unified_job_template: OpenShift / CNV / Wait Hosts
         failure_nodes:
-          - Inventory Sync
-      - identifier: Inventory Sync
+          - Second Inventory Sync
+      - identifier: Second Inventory Sync
         unified_job_template: OpenShift CNV Inventory
 
   - name: OpenShift / CNV / Infra Stack

--- a/openshift/setup.yml
+++ b/openshift/setup.yml
@@ -245,6 +245,34 @@ controller_templates:
       - "OpenShift Credential"
 
 controller_workflows:
+  - name: OpenShift / CNV / Sync Hosts
+    description: A workflow to update dynamic CNV inventory and wait for hosts to become avilable
+    organization: Default
+    notification_templates_started: Telemetry
+    notification_templates_success: Telemetry
+    notification_templates_error: Telemetry
+    survey_enabled: true
+    survey:
+      name: ''
+      description: ''
+      spec:
+        - question_name: Specify target hosts
+          type: text
+          variable: _hosts
+          required: true
+          default: "openshift-cnv-rhel*"
+    simplified_workflow_nodes:
+      - identifier: Inventory Sync
+        unified_job_template: OpenShift CNV Inventory
+        success_nodes:
+          - Wait Hosts
+      - identifier: Wait Hosts
+        unified_job_template: OpenShift / CNV / Wait Hosts
+        failure_nodes:
+          - Inventory Sync
+    - identifier: Inventory Sync
+        unified_job_template: OpenShift CNV Inventory
+
   - name: OpenShift / CNV / Infra Stack
     description: A workflow to deploy Virtualized infra in OCP Virtalization
     organization: Default
@@ -320,15 +348,15 @@ controller_workflows:
         success_nodes:
           - Patch Instance
       # We need to do an invnetory sync *after* creating snapshots, as turning VMs on/off changes their IP
-      - identifier: Inventory Sync
-        unified_job_template: OpenShift CNV Inventory
+      - identifier: Sync Hosts
+        unified_job_template: OpenShift / CNV / Sync Hosts
         success_nodes:
           - Patch Instance
       - identifier: Take Snapshot
         unified_job_template: OpenShift / CNV / Create VM Snapshots
         success_nodes:
           - Project Sync
-          - Inventory Sync
+          - Sync Hosts
       - identifier: Patch Instance
         unified_job_template: OpenShift / CNV / Patch
         job_type: run


### PR DESCRIPTION
Still I'm running into this super annoying issue with the patching workflow. A snapshot requires the VM go to down, when it comes back up it is assigned a new IP address and there seems to be a race condition where the inventory sync sometimes returns the previous IP, not the new one. This is a work-around to try to wait for the hosts to come up.  