### PR TITLE
update Setup JT name in Satellite demo

### DIFF
--- a/satellite/setup.yml
+++ b/satellite/setup.yml
@@ -192,7 +192,7 @@ controller_templates:
       - Satellite Credential
 
 controller_launch_jobs:
-  - name: SETUP
+  - name: "APD | Single demo setup"
     wait: false
     extra_vars:
       demo: linux


### PR DESCRIPTION
We forgot this weird thing the Satellite demo does when we changed the SETUP job name.