### PR TITLE
EE builds for 2.5 through 2.7 with version pinning

### DIFF
--- a/execution_environments/apd-ee-26.yml
+++ b/execution_environments/apd-ee-26.yml
@@ -4,7 +4,7 @@ images:
   base_image:
     name: registry.redhat.io/ansible-automation-platform-26/ee-minimal-rhel9:latest
 dependencies:
-  galaxy: requirements.yml
+  galaxy: requirements-26.yml
   system:
     - python3.12-devel [platform:rpm]
     # development requirements for ansible.eda collection, removed in append_final

--- a/execution_environments/apd-ee-27.yml
+++ b/execution_environments/apd-ee-27.yml
@@ -2,9 +2,9 @@
 version: 3
 images:
   base_image:
-    name: registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel9:latest
+    name: registry.redhat.io/ansible-automation-platform-27/ee-minimal-rhel9:2.20-1783620286
 dependencies:
-  galaxy: requirements-25.yml
+  galaxy: requirements-27.yml
   system:
     - python3.12-devel [platform:rpm]
     # development requirements for ansible.eda collection, removed in append_final

--- a/execution_environments/build.sh
+++ b/execution_environments/build.sh
@@ -10,7 +10,7 @@ then
     then
         echo "RHEL does not include the necessary QEMU RPMs for creating multi-arch EE images,"
         echo "please run this script on a Fedora system with the qemu-user-static RPM installed"
-    exit 1
+        exit 1
     fi
 
     if [[ "$ID" == "fedora" ]]

--- a/execution_environments/build.sh
+++ b/execution_environments/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 manifest=${1:-quay.io/ansible-product-demos/apd-ee-26}
+image="${manifest##*/}"  # everything up to and including last slash, e.g. "apd-ee-26"
 
 if [[ -z $ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN || -z $ANSIBLE_GALAXY_SERVER_VALIDATED_TOKEN ]]
 then
@@ -19,7 +20,7 @@ fi
 # create EE definition
 rm -rf ./context/*
 ansible-builder create \
-    --file apd-ee-26.yml \
+    --file ${image}.yml \
     --context ./context \
     -v 3 | tee ansible-builder.log
 

--- a/execution_environments/build.sh
+++ b/execution_environments/build.sh
@@ -2,9 +2,31 @@
 manifest=${1:-quay.io/ansible-product-demos/apd-ee-26}
 image="${manifest##*/}"  # everything up to and including last slash, e.g. "apd-ee-26"
 
+if [[ "$(uname -s)" == "Linux" ]]
+then
+    source /etc/os-release
+
+    if [[ "$ID" == "rhel" ]]
+    then
+        echo "RHEL does not include the necessary QEMU RPMs for creating multi-arch EE images,"
+        echo "please run this script on a Fedora system with the qemu-user-static RPM installed"
+    exit 1
+    fi
+
+    if [[ "$ID" == "fedora" ]]
+    then
+        if ! rpm -q --quiet qemu-user-static
+        then
+            echo "Please install the qemu-user-static RPM before continuing, it is required"
+            echo "for building multi-arch EE images"
+            exit 1
+        fi
+    fi
+fi
+
 if [[ -z $ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN || -z $ANSIBLE_GALAXY_SERVER_VALIDATED_TOKEN ]]
 then
-    echo "A valid Automation Hub token is required, Set the following environment variables before continuing"
+    echo "A valid Automation Hub token is required, set the following environment variables before continuing:"
     echo "export ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN=<token>"
     echo "export ANSIBLE_GALAXY_SERVER_VALIDATED_TOKEN=<token>"
     exit 1

--- a/execution_environments/requirements-25.yml
+++ b/execution_environments/requirements-25.yml
@@ -1,0 +1,104 @@
+---
+collections:
+  # AAP config as code, see https://access.redhat.com/articles/7143507 for version pinning
+  - name: ansible.controller
+    version: ">=4.6,<4.7"
+  - name: ansible.eda
+    version: ">=2.1.0"
+  - name: ansible.hub
+    version: ">=1.0.0"
+  - name: ansible.platform
+    version: ">=2.5,<2.6"
+  - name: infra.ah_configuration
+    version: "2.1.0"
+  - name: infra.controller_configuration
+    version: "3.1.2"
+  - name: infra.aap_configuration
+    version: ">=3.4.1"
+  # linux demos
+  - name: ansible.posix
+    version: ">=1.5.4"
+  - name: community.general
+    version: ">=8.0.0"
+  - name: containers.podman
+    version: ">=1.12.1"
+  - name: redhat.insights
+    version: ">=1.2.2"
+  - name: redhat.rhel_system_roles
+    version: ">=1.23.0"
+  # windows demos
+  - name: microsoft.ad
+    version: "1.9"
+  - name: ansible.windows
+    version: ">=2.3.0"
+  - name: chocolatey.chocolatey
+    version: ">=1.5.1"
+  - name: community.windows
+    version: ">=2.2.0"
+  # cloud demos
+  - name: amazon.aws
+    version: ">=7.5.0"
+  - name: community.aws
+    version: ">=7.0.0"
+  # satellite demos
+  - name: redhat.satellite
+    version: ">=4.0.0"
+  # network demos
+  - name: ansible.netcommon
+    version: ">=6.0.0"
+  - name: cisco.ios
+    version: ">=7.0.0"
+  - name: cisco.iosxr
+    version: ">=8.0.0"
+  - name: cisco.nxos
+    version: ">=7.0.0"
+  - name: network.backup
+    version: ">=3.0.0"
+  - name: paloaltonetworks.panos
+    version: ">=3.2.0"
+  - name: infoblox.nios_modules
+    version: ">=1.6.1"
+  # openshift demos
+  - name: ansible.utils
+    version: ">=6.0.0"
+  - name: kubernetes.core
+    version: ">=4.0.0"
+  - name: redhat.openshift
+    version: ">=3.0.1"
+  - name: redhat.openshift_virtualization
+    version: ">=1.4.0"
+  # other demos
+  - name: cloud.terraform
+    version: ">=4.0.0"
+  - name: hashicorp.terraform
+    version: ">=1.1.0"
+  - name: hashicorp.vault
+    version: ">=1.0.0"
+  - name: servicenow.itsm
+    version: ">=2.13.0"
+  - name: redhat.rhbk
+    version: ">=3.0.0"
+  - name: redhat.rhel_idm
+    version: ">=1.15.0"
+
+roles:
+  # RHEL 8 compliance roles from ComplianceAsCode
+  - name: RedHatOfficial.rhel8_cis
+  - name: RedHatOfficial.rhel8_hipaa
+  - name: RedHatOfficial.rhel8_ospp
+  - name: RedHatOfficial.rhel8_pci_dss
+  - name: RedHatOfficial.rhel8_stig
+  # RHEL 9 compliance roles from ComplianceAsCode
+  - name: RedHatOfficial.rhel9_cis
+  - name: RedHatOfficial.rhel9_hipaa
+  - name: RedHatOfficial.rhel9_ospp
+  - name: RedHatOfficial.rhel9_pci_dss
+  - name: RedHatOfficial.rhel9_stig
+  # RHEL 10 compliance roles from ComplianceAsCode
+  - name: RedHatOfficial.rhel10_cis
+  - name: RedHatOfficial.rhel10_hipaa
+  - name: RedHatOfficial.rhel10_ospp
+  - name: RedHatOfficial.rhel10_pci_dss
+  - name: RedHatOfficial.rhel10_stig
+
+...

--- a/execution_environments/requirements-26.yml
+++ b/execution_environments/requirements-26.yml
@@ -1,0 +1,100 @@
+---
+collections:
+  # AAP config as code, see https://access.redhat.com/articles/7143507 for version pinning
+  - name: ansible.controller
+    version: ">=4.7,<4.8"
+  - name: ansible.eda
+    version: ">=2.1.0"
+  - name: ansible.hub
+    version: ">=1.0.4,<1.0.6"
+  - name: ansible.platform
+    version: ">=2.6,<2.7"
+  - name: infra.aap_configuration
+    version: ">=3.4.1"
+  # linux demos
+  - name: ansible.posix
+    version: ">=1.5.4"
+  - name: community.general
+    version: ">=8.0.0"
+  - name: containers.podman
+    version: ">=1.12.1"
+  - name: redhat.insights
+    version: ">=1.2.2"
+  - name: redhat.rhel_system_roles
+    version: ">=1.23.0"
+  # windows demos
+  - name: microsoft.ad
+    version: ">=1.9"
+  - name: ansible.windows
+    version: ">=2.3.0"
+  - name: chocolatey.chocolatey
+    version: ">=1.5.1"
+  - name: community.windows
+    version: ">=2.2.0"
+  # cloud demos
+  - name: amazon.aws
+    version: ">=7.5.0"
+  - name: community.aws
+    version: ">=7.0.0"
+  # satellite demos
+  - name: redhat.satellite
+    version: ">=4.0.0"
+  # network demos
+  - name: ansible.netcommon
+    version: ">=6.0.0"
+  - name: cisco.ios
+    version: ">=7.0.0"
+  - name: cisco.iosxr
+    version: ">=8.0.0"
+  - name: cisco.nxos
+    version: ">=7.0.0"
+  - name: network.backup
+    version: ">=3.0.0"
+  - name: paloaltonetworks.panos
+    version: ">=3.2.0"
+  - name: infoblox.nios_modules
+    version: ">=1.6.1"
+  # openshift demos
+  - name: ansible.utils
+    version: ">=6.0.0"
+  - name: kubernetes.core
+    version: ">=4.0.0"
+  - name: redhat.openshift
+    version: ">=3.0.1"
+  - name: redhat.openshift_virtualization
+    version: ">=1.4.0"
+  # other demos
+  - name: cloud.terraform
+    version: ">=4.0.0"
+  - name: hashicorp.terraform
+    version: ">=1.1.0"
+  - name: hashicorp.vault
+    version: ">=1.0.0"
+  - name: servicenow.itsm
+    version: ">=2.13.0"
+  - name: redhat.rhbk
+    version: ">=3.0.0"
+  - name: redhat.rhel_idm
+    version: ">=1.15.0"
+
+roles:
+  # RHEL 8 compliance roles from ComplianceAsCode
+  - name: RedHatOfficial.rhel8_cis
+  - name: RedHatOfficial.rhel8_hipaa
+  - name: RedHatOfficial.rhel8_ospp
+  - name: RedHatOfficial.rhel8_pci_dss
+  - name: RedHatOfficial.rhel8_stig
+  # RHEL 9 compliance roles from ComplianceAsCode
+  - name: RedHatOfficial.rhel9_cis
+  - name: RedHatOfficial.rhel9_hipaa
+  - name: RedHatOfficial.rhel9_ospp
+  - name: RedHatOfficial.rhel9_pci_dss
+  - name: RedHatOfficial.rhel9_stig
+  # RHEL 10 compliance roles from ComplianceAsCode
+  - name: RedHatOfficial.rhel10_cis
+  - name: RedHatOfficial.rhel10_hipaa
+  - name: RedHatOfficial.rhel10_ospp
+  - name: RedHatOfficial.rhel10_pci_dss
+  - name: RedHatOfficial.rhel10_stig
+
+...

--- a/execution_environments/requirements-27.yml
+++ b/execution_environments/requirements-27.yml
@@ -1,18 +1,14 @@
 ---
 collections:
-  # AAP config as code
+  # AAP config as code, see https://access.redhat.com/articles/7143507 for version pinning
   - name: ansible.controller
-    version: ">=4.6.0"
+    version: ">=4.8"
   - name: ansible.eda
-    version: ">=2.1.0"
+    version: ">=2.12.0"
   - name: ansible.hub
-    version: ">=1.0.0"
+    version: ">=1.0.6"
   - name: ansible.platform
-    version: ">=2.5.0"
-  - name: infra.ah_configuration
-    version: "2.1.0"
-  - name: infra.controller_configuration
-    version: "3.1.2"
+    version: ">=2.7"
   - name: infra.aap_configuration
     version: ">=3.4.1"
   # linux demos
@@ -28,7 +24,7 @@ collections:
     version: ">=1.23.0"
   # windows demos
   - name: microsoft.ad
-    version: "1.9"
+    version: ">=1.10"
   - name: ansible.windows
     version: ">=2.3.0"
   - name: chocolatey.chocolatey
@@ -56,8 +52,6 @@ collections:
     version: ">=3.0.0"
   - name: paloaltonetworks.panos
     version: ">=3.2.0"
-  # TODO on 2.5 ee-minimal-rhel9 this tries to build and install
-  # a different version of python netifaces, which fails
   - name: infoblox.nios_modules
     version: ">=1.6.1"
   # openshift demos


### PR DESCRIPTION
the collections used for creating AAP resources (ansible.platform, ansible.controller, etc.) aren't guaranteed to be backwards compatible with newer versions of AAP, and need to be version pinned (see https://access.redhat.com/articles/7143507).  this PR updates the EE build script and input files to create an EE per version of AAP with the correct collection pinning.