### PR TITLE
fix: correct repository in Jekyll config

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,7 @@ title: Ansible Product Demos
 description: Demo catalog and presenter guides for Red Hat Ansible Automation Platform
 url: https://ansible.github.io
 baseurl: /product-demos
-repository: IPvSean/product-demos
+repository: ansible/product-demos
 
 markdown: kramdown
 theme: null


### PR DESCRIPTION
## Summary

- Fix `repository` field in `docs/_config.yml` from `IPvSean/product-demos` to `ansible/product-demos`
- This was missed when the fork URLs were updated in #311

One-line fix.

Made with [Cursor](https://cursor.com)