### PR TITLE
Address collection metadata warnings and improve documentation

### DIFF
--- a/collections/ansible_collections/demo/cloud/README.md
+++ b/collections/ansible_collections/demo/cloud/README.md
@@ -10,12 +10,12 @@ This collection is not published to Ansible Galaxy or Automation Hub; it exists 
 
 | Role | Description |
 |------|-------------|
-| [aws](roles/aws/) | Create, resize, snapshot, restore, and destroy AWS EC2 instances and supporting VPC infrastructure. |
+| [aws](roles/aws/README.md) | Create, resize, snapshot, restore, and destroy AWS EC2 instances and supporting VPC infrastructure. |
 | [build_report_s3](roles/build_report_s3/README.md) | Build and publish an HTML report to an S3-hosted static website. |
 | [build_report_linux](roles/build_report_linux/README.md) | Install Apache and build an HTML report from Linux services and packages facts. |
 | [manage_direct_peered_networks](roles/manage_direct_peered_networks/README.md) | Create or delete a direct VPC peering model (DMZ + private network) in AWS. |
 | [manage_transit_peered_networks](roles/manage_transit_peered_networks/README.md) | Create or delete a hub-and-spoke transit gateway VPC network model in AWS. |
-| [reports](roles/reports/) | Create an S3-hosted report bucket, sync report files, and publish a landing page. |
-| [retrieve_aws_instances_info](roles/retrieve_aws_instances_info/) | Gather service/package facts and verify EC2 instance and webserver reachability. |
-| [retrieve_info](roles/retrieve_info/) | Retrieve VPC, EC2 instance, and Internet Gateway information for one or more AWS regions. |
+| [reports](roles/reports/README.md) | Create an S3-hosted report bucket, sync report files, and publish a landing page. |
+| [retrieve_aws_instances_info](roles/retrieve_aws_instances_info/README.md) | Gather service/package facts and verify EC2 instance and webserver reachability. |
+| [retrieve_info](roles/retrieve_info/README.md) | Retrieve VPC, EC2 instance, and Internet Gateway information for one or more AWS regions. |
 | [template](roles/template/README.md) | Shared report page templates (header, footer, VPC, ansible) used by the reporting roles. |

--- a/collections/ansible_collections/demo/cloud/README.md
+++ b/collections/ansible_collections/demo/cloud/README.md
@@ -1,0 +1,21 @@
+# demo.cloud
+
+Local collection containing roles used by the [Cloud demos](../../../../cloud/README.md) in ansible-product-demos.
+
+This collection is not published to Ansible Galaxy or Automation Hub; it exists solely to organize roles used by playbooks in this repository under the `demo.cloud` namespace.
+
+## Contents
+
+### Roles
+
+| Role | Description |
+|------|-------------|
+| [aws](roles/aws/) | Create, resize, snapshot, restore, and destroy AWS EC2 instances and supporting VPC infrastructure. |
+| [build_report_s3](roles/build_report_s3/README.md) | Build and publish an HTML report to an S3-hosted static website. |
+| [build_report_linux](roles/build_report_linux/README.md) | Install Apache and build an HTML report from Linux services and packages facts. |
+| [manage_direct_peered_networks](roles/manage_direct_peered_networks/README.md) | Create or delete a direct VPC peering model (DMZ + private network) in AWS. |
+| [manage_transit_peered_networks](roles/manage_transit_peered_networks/README.md) | Create or delete a hub-and-spoke transit gateway VPC network model in AWS. |
+| [reports](roles/reports/) | Create an S3-hosted report bucket, sync report files, and publish a landing page. |
+| [retrieve_aws_instances_info](roles/retrieve_aws_instances_info/) | Gather service/package facts and verify EC2 instance and webserver reachability. |
+| [retrieve_info](roles/retrieve_info/) | Retrieve VPC, EC2 instance, and Internet Gateway information for one or more AWS regions. |
+| [template](roles/template/README.md) | Shared report page templates (header, footer, VPC, ansible) used by the reporting roles. |

--- a/collections/ansible_collections/demo/cloud/galaxy.yml
+++ b/collections/ansible_collections/demo/cloud/galaxy.yml
@@ -1,0 +1,17 @@
+---
+namespace: demo
+name: cloud
+version: 1.0.0+08062601
+readme: README.md
+authors:
+  - Ansible Product Demos (https://github.com/ansible/product-demos)
+description: Roles supporting multi-cloud provisioning and management demos in ansible-product-demos.
+license:
+  - GPL-3.0-or-later
+tags:
+  - apd
+  - cloud
+  - aws
+repository: https://github.com/ansible/product-demos
+issues: https://github.com/ansible/product-demos/issues
+...

--- a/collections/ansible_collections/demo/cloud/meta/runtime.yml
+++ b/collections/ansible_collections/demo/cloud/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: ">=2.16.0"

--- a/collections/ansible_collections/demo/cloud/roles/aws/README.md
+++ b/collections/ansible_collections/demo/cloud/roles/aws/README.md
@@ -44,7 +44,7 @@ Defaults live in `defaults/main.yml`.
 | `create_vm_vm_deployment` / `create_vm_vm_environment` / `create_vm_vm_owner` / `create_vm_vm_purpose` | `default` / `default` / `ansible` / `demo` | Tags used both for idempotency lookups and on the created instance |
 | `create_vm_aws_image_filter` | `RHEL-9*HVM-*Hourly*` | AMI name filter for `ec2_ami_info` |
 | `create_vm_aws_image_architecture` | `x86_64` | AMI architecture filter |
-| `create_vm_aws_userdata_template` | unset | Template name (`<name>.j2` in `templates/`) rendered as EC2 user-data; must be supplied (for example by `cloud/blueprints/windows_full.yml`, which sets it to `aws_windows_userdata`) -- RHEL blueprints don't set it, and the older `cloud/blueprints/windows.yml` sets the legacy unprefixed `aws_userdata_template` instead, which this role's `create_vm` no longer reads |
+| `create_vm_aws_userdata_template` | `default` | Template name (`<name>.j2` in `templates/`) rendered as EC2 user-data; defaults to `default` (`templates/default.j2`). Windows blueprints such as `cloud/blueprints/windows_full.yml` override it to `aws_windows_userdata`. The older `cloud/blueprints/windows.yml` sets the legacy unprefixed `aws_userdata_template` instead, which this role's `create_vm` no longer reads |
 
 `instance_id`, `instance_type`, and `tags` are required caller-supplied variables for `resize_ec2` / `snapshot_vm` / `restore_vm` / `destroy_vm` (not set in `defaults/main.yml`).
 

--- a/collections/ansible_collections/demo/cloud/roles/aws/README.md
+++ b/collections/ansible_collections/demo/cloud/roles/aws/README.md
@@ -1,0 +1,68 @@
+# demo.cloud.aws
+
+Create, resize, snapshot, restore, and destroy AWS EC2 instances and the supporting VPC/subnet/security-group/keypair infrastructure for the cloud demos.
+
+Invoke with `include_role` and `tasks_from` -- this role has no `tasks/main.yml`, so it cannot be called without selecting an entry point.
+
+```yaml
+- name: Include create vm role
+  ansible.builtin.include_role:
+    name: demo.cloud.aws
+    tasks_from: create_vm
+```
+
+`create_vm` is idempotent: it first looks for an existing instance matching the full tag set (name, blueprint, environment, deployment, owner, purpose) and reuses it if found, otherwise it resolves the subnet/AMI and creates a new instance; either way the public/private IPs are exported via `set_stats`. The other entry points (`resize_ec2`, `snapshot_vm`, `restore_vm`, `destroy_vm`) act on an existing `instance_id` and are typically run with `delegate_to: localhost` against a host already known to AAP.
+
+Repo playbooks: [`cloud/create_vm.yml`](../../../../../../cloud/create_vm.yml), [`cloud/resize_ec2.yml`](../../../../../../cloud/resize_ec2.yml), [`cloud/snapshot_ec2.yml`](../../../../../../cloud/snapshot_ec2.yml), [`cloud/restore_ec2.yml`](../../../../../../cloud/restore_ec2.yml).
+
+`create_infra` and `destroy_vm` are not currently invoked by any repo playbook -- [`cloud/create_vpc.yml`](../../../../../../cloud/create_vpc.yml)/[`cloud/delete_vpc.yml`](../../../../../../cloud/delete_vpc.yml) and [`cloud/delete_vm_by_name.yml`](../../../../../../cloud/delete_vm_by_name.yml) implement equivalent logic with inline `amazon.aws` tasks instead of this role.
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: `localhost` (all tasks are AWS API calls, several explicitly `delegate_to: localhost`)
+- `amazon.aws` collection (`ec2_instance`, `ec2_instance_info`, `ec2_vpc_*`, `ec2_vol*`, `ec2_snapshot*`, `ec2_key`, `ec2_security_group`, `ec2_ami_info`)
+- `infra.controller_configuration` collection (`inventory_source_update`, used by `resize_ec2` to refresh AAP inventory)
+- AWS credentials available to the `amazon.aws` modules (for example an AAP AWS credential injecting the usual `AWS_*` environment variables)
+
+## Role Variables
+
+Defaults live in `defaults/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `aws_vpc_name` / `aws_vpc_prefix` | `ansible` / `demo` | Used to derive the VPC, keypair, and security group names in `create_infra` |
+| `aws_vpc_cidr_block` / `aws_subnet_cidr` | `10.0.0.0/16` / `10.0.1.0/24` | CIDRs for the VPC and its subnet (`create_infra`) |
+| `aws_region` | `us-east-1` | Region for `create_infra` and the `snapshot_vm` / `restore_vm` / `resize_ec2` entry points |
+| `aws_keypair_name` / `aws_securitygroup_name` | derived from `aws_vpc_name`/`aws_vpc_prefix` | Names used by `create_infra` |
+| `aws_ec2_wait` | `true` | Whether `create_infra` waits for resources to reach their target state |
+| `aws_snapshots` | `{}` | Populated by `snapshot_vm` (`set_stats`) and consumed by `restore_vm` to attach the correct snapshot per volume |
+| `create_vm_vm_name` | `demo_vm` | `Name` tag / idempotency key for `create_vm` |
+| `create_vm_aws_region` | `us-east-1` | Region for `create_vm` |
+| `create_vm_aws_instance_size` | `t2.micro` | Instance type for `create_vm` |
+| `create_vm_aws_tenancy` | `default` | Tenancy for `create_vm` |
+| `create_vm_vm_deployment` / `create_vm_vm_environment` / `create_vm_vm_owner` / `create_vm_vm_purpose` | `default` / `default` / `ansible` / `demo` | Tags used both for idempotency lookups and on the created instance |
+| `create_vm_aws_image_filter` | `RHEL-9*HVM-*Hourly*` | AMI name filter for `ec2_ami_info` |
+| `create_vm_aws_image_architecture` | `x86_64` | AMI architecture filter |
+| `create_vm_aws_userdata_template` | unset | Template name (`<name>.j2` in `templates/`) rendered as EC2 user-data; must be supplied (for example by `cloud/blueprints/windows_full.yml`, which sets it to `aws_windows_userdata`) -- RHEL blueprints don't set it, and the older `cloud/blueprints/windows.yml` sets the legacy unprefixed `aws_userdata_template` instead, which this role's `create_vm` no longer reads |
+
+`instance_id`, `instance_type`, and `tags` are required caller-supplied variables for `resize_ec2` / `snapshot_vm` / `restore_vm` / `destroy_vm` (not set in `defaults/main.yml`).
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `create_vm` | Reuse a matching existing instance by tag, or resolve the subnet/AMI and create a new one; exports IPs via `set_stats`. |
+| `create_infra` | Create the demo VPC, Internet Gateway, security group (WinRM/RDP/HTTP/AD ports), subnet, route table, and keypair. |
+| `resize_ec2` | Stop, resize (`instance_type`), and restart an instance, then refresh the AAP AWS inventory source. |
+| `snapshot_vm` | Snapshot every EBS volume attached to `instance_id` and record the snapshot IDs in `aws_snapshots` via `set_stats`. |
+| `restore_vm` | Stop the instance, detach current volumes, and reattach either the recorded `aws_snapshots` entry or the latest matching snapshot, then restart. |
+| `destroy_vm` | Terminate the instance identified by `instance_id`. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.cloud`](../../README.md) for the AWS cloud demos in this repository.

--- a/collections/ansible_collections/demo/cloud/roles/build_report_linux/README.md
+++ b/collections/ansible_collections/demo/cloud/roles/build_report_linux/README.md
@@ -1,11 +1,47 @@
-# network.toolkit.build_report
+# demo.cloud.build_report_linux
 
-To use this multi-platform network automation build_report role:
+Install Apache on a Linux host, template a cloud infrastructure HTML report, and print the public URL to view it -- used as the report server for the AWS cloud demos when the report is hosted on a VM rather than S3.
 
-## Task example:
-
+```yaml
+- name: Load report to host on Linux
+  ansible.builtin.include_role:
+    name: demo.cloud.build_report_linux
+  when: inventory_hostname != 'localhost'
 ```
-- name: build a report
-  include_role:
-    name: build_report
-```
+
+Run after `demo.cloud.retrieve_info` and `demo.cloud.template` have gathered facts and rendered `index.html`; this role installs and configures the actual Apache server and publishes the assets. Public IP is looked up from `https://checkip.amazonaws.com` to build the printed URL.
+
+Repo playbook: [`cloud/cloud_report.yml`](../../../../../../cloud/cloud_report.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: RHEL host with `become` and `dnf`
+- `ansible.posix` collection (`seboolean`)
+- Outbound network access from the target to `https://checkip.amazonaws.com` (used only to print the report URL; failures are ignored)
+
+## Role Variables
+
+Defaults live in `vars/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `file_path` | `/var/www/html/` | Apache document root where the report, CSS, and images are copied |
+| `web_host` | `ansible-1` | Informational hostname referenced when printing host vars |
+| `web_port` | `8088` | Port Apache is reconfigured to listen on |
+| `vendor` | `{ios: Cisco, nxos: Cisco, iosxr: Cisco, junos: Juniper, eos: Arista}` | Unused by this role's own tasks; shared boilerplate vars file copied from the network reporting roles |
+| `transport` | `{cliconf: network_cli, netconf: netconf, httpapi: httpapi}` | Unused by this role's own tasks; shared boilerplate vars file copied from the network reporting roles |
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Install and start Apache on `web_port`, template `index.html`, copy CSS/image assets, and print the report URL. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.cloud`](../../README.md) for the AWS cloud reporting demos in this repository.

--- a/collections/ansible_collections/demo/cloud/roles/build_report_s3/README.md
+++ b/collections/ansible_collections/demo/cloud/roles/build_report_s3/README.md
@@ -1,11 +1,45 @@
-# network.toolkit.build_report
+# demo.cloud.build_report_s3
 
-To use this multi-platform network automation build_report role:
+Create (or update) an S3 bucket configured as a static website, sync a local report directory into it, and publish an `index.html`, for AWS cloud demo reports hosted directly on S3 instead of a VM.
 
-## Task example:
-
+```yaml
+- name: Load report to host on AWS S3
+  ansible.builtin.include_role:
+    name: demo.cloud.build_report_s3
+  when: inventory_hostname == 'localhost'
 ```
-- name: build a report
-  include_role:
-    name: build_report
-```
+
+Run after `demo.cloud.retrieve_info` and `demo.cloud.template` have rendered `index.html` in `playbook_dir`. The bucket policy is rendered from `templates/policy.json` to allow public read access to the website content.
+
+Repo playbook: [`cloud/cloud_report.yml`](../../../../../../cloud/cloud_report.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: `localhost`
+- `amazon.aws` collection (`s3_bucket`, `s3_object`, `s3_object_info`)
+- `community.aws` collection (`s3_website`, `s3_sync`)
+- AWS credentials with permission to create/configure S3 buckets and objects
+
+## Role Variables
+
+Defaults live in `vars/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `reports_aws_bucket_name` | `aws-cloud-report` | S3 bucket created/configured as a static website |
+| `reports_aws_region` | `us-west-1` | AWS region for the bucket |
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Create the report bucket (public-read policy from `templates/policy.json`), enable static website hosting, sync `files/` from `playbook_dir`, upload `index.html`, and print the bucket website URL. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.cloud`](../../README.md) for the AWS cloud reporting demos in this repository.

--- a/collections/ansible_collections/demo/cloud/roles/manage_direct_peered_networks/README.md
+++ b/collections/ansible_collections/demo/cloud/roles/manage_direct_peered_networks/README.md
@@ -1,51 +1,83 @@
-# Peer Network Deployment Role
+# demo.cloud.manage_direct_peered_networks
 
-This Ansible role contains repeatable peer networking automation that can help establish template infrastructure configurations that may be used for starting an AWS networking infrastructure strategy or to create demonstrations for network peering scenarios.
-
-## Create Peer Networks
-
-This operation will create peer network model with two VPCs; one acting as a public internet-facing DMZ where bastion servers and other internet resources could exist, and another that acts as an entirely private network with no internet access.  These networks are peered together with security groups and routing rules that allow traffic between the two VPCs and their subnets.  Once deployed, you can SSH in to the bastion host in order to can access to the host on the private network.
-
-### Variables
-
-The following variables are used during deployment and can be configured as extra vars at deploy time if you require something other than the defaults.
-
-#### Required
+Create or delete a direct VPC peering model in AWS: a public-facing DMZ VPC (with a bastion host) peered to an entirely private VPC, connected with security groups and routing rules so the DMZ can reach hosts on the private network.
 
 ```yaml
----
+- name: Create Peer Networking Model
+  ansible.builtin.include_role:
+    name: demo.cloud.manage_direct_peered_networks
+  vars:
+    manage_direct_peered_networks_operation: create
+```
+
+Once deployed, SSH to the bastion host in the DMZ to reach hosts on the private network. Set `manage_direct_peered_networks_operation` to `create` or `delete` before including the role -- that value selects which task file runs.
+
+Repo playbooks: [`cloud/create_peer_network.yml`](../../../../../../cloud/create_peer_network.yml), [`cloud/delete_peer_network.yml`](../../../../../../cloud/delete_peer_network.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: `localhost`
+- `amazon.aws` collection (VPC, subnet, security group, and EC2 resources)
+- AWS credentials with permission to create/delete VPCs, subnets, security groups, peering connections, route tables, and EC2 instances
+- For `delete`: the same tags used at `create` time, so matching resources can be located and removed
+
+## Role Variables
+
+Defaults live in `defaults/main.yml`.
+
+### Required (caller-supplied, no default)
+
+```yaml
 aws_region: us-east-1 # The region in which the resources are deployed
 dmz_ssh_key_name: aws-test-key # The AWS SSH key to use when configuring access to the EC2 instances
 ```
 
-#### Optional
+### Optional
 
-```yaml
----
-# These variables can be configured to change the VPC networks and the EC2 instances deployed into them.
-tenancy: default
-vpc_priv_net_cidr: 10.0.0.0/16
-vpc_priv_net_priv_subnet_cidr: 10.0.0.0/24
-vpc_dmz_cidr: 10.1.0.0/16
-vpc_dmz_subnet1_cidr: 10.1.0.0/24
-dmz_instance_type: t2.micro
-dmz_instance_ami_owner: "{{ omit }}"
-dmz_instance_ami_architecture: x86_64
-dmz_instance_ami_filter: RHEL-8*HVM-*Hourly*
-dmz_instance_ami: undef # use this variable to override the AMI lookup
-dmz_instance_name: dmz-ssh-tunnel-vm
-priv_network_instance_type: t2.micro
-priv_network_instance_ami_owner: "{{ omit }}"
-priv_network_instance_ami_architecture: x86_64
-priv_network_instance_ami_filter: RHEL-8*HVM-*Hourly*
-priv_network_instance_name: priv-network-vm
-priv_natwork_instance_ami: undef # use this variable to override the AMI lookup
-```
+| Variable | Default | Description |
+| --- | --- | --- |
+| `tenancy` | `default` | EC2 tenancy for both VPCs' instances |
+| `vpc_priv_net_cidr` | `10.0.0.0/16` | Private VPC CIDR |
+| `vpc_priv_net_public_subnet_cidr` | `10.0.0.0/24` | Private VPC's public-facing subnet CIDR |
+| `vpc_priv_net_priv_subnet_cidr` | `10.0.1.0/24` | Private VPC's private subnet CIDR |
+| `vpc_priv_net_hosts_pattern` | `10.0.*` | Host pattern used by the caller's SSH config for the private network |
+| `vpc_dmz_cidr` | `10.1.0.0/16` | DMZ VPC CIDR |
+| `vpc_dmz_subnet1_cidr` | `10.1.0.0/24` | DMZ VPC subnet CIDR |
+| `dmz_instance_type` | `t2.micro` | Instance type for the DMZ bastion |
+| `dmz_instance_ami_owner` | `{{ omit }}` | AMI owner filter for the DMZ bastion |
+| `dmz_instance_ami_architecture` | `x86_64` | AMI architecture filter for the DMZ bastion |
+| `dmz_instance_ami_filter` | `RHEL-8*HVM-*Hourly*` | AMI name filter for the DMZ bastion |
+| `dmz_instance_ami` | unset | Override to skip the AMI lookup entirely |
+| `dmz_instance_name` | `dmz-ssh-tunnel-vm` | Name tag for the DMZ bastion |
+| `priv_network_instance_type` | `t2.micro` | Instance type for the private-network VM |
+| `priv_network_instance_ami_owner` | `{{ omit }}` | AMI owner filter for the private-network VM |
+| `priv_network_instance_ami_architecture` | `x86_64` | AMI architecture filter for the private-network VM |
+| `priv_network_instance_ami_filter` | `RHEL-8*HVM-*Hourly*` | AMI name filter for the private-network VM |
+| `priv_network_instance_name` | `priv-network-vm` | Name tag for the private-network VM |
+| `priv_natwork_instance_ami` | unset | Override to skip the AMI lookup entirely (note: variable name as shipped) |
 
-### Infrastructure
+## Infrastructure
 
-The following AWS infrastructure resources are created during this deployment.  Each resource is configured with a set of tags that are used to determine if resources already exist, and which resources to clean up if the `delete` operation is run.
+The following AWS infrastructure resources are created during `create` and removed during `delete`. Each resource is tagged so the role can determine whether resources already exist, and which resources to clean up.
 
 ### Architecture Diagram
 
-![Deployment Architecture Diagram](./files/peer_network_arch_diagram.png)
+![Deployment Architecture Diagram](files/peer_network_arch_diagram.png)
+
+## Entry points
+
+The role always runs `tasks/main.yml`, which validates `manage_direct_peered_networks_operation` and includes one of the files below:
+
+| Entry point | Description |
+| --- | --- |
+| `create` | Create both VPCs, subnets, security groups, peering connection, routing, and the DMZ/private-network EC2 instances. |
+| `delete` | Tear down the peering connection, EC2 instances, security groups, subnets, and VPCs created by `create`. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.cloud`](../../README.md) for the AWS network peering demos in this repository.

--- a/collections/ansible_collections/demo/cloud/roles/manage_transit_peered_networks/README.md
+++ b/collections/ansible_collections/demo/cloud/roles/manage_transit_peered_networks/README.md
@@ -1,61 +1,94 @@
-# Transit Network Deployment Role
+# demo.cloud.manage_transit_peered_networks
 
-This Ansible role contains repeatable automation for a hub-and-spoke VPC peering model that can help establish template infrastructure configurations that may be used for starting an AWS networking infrastructure strategy or to create demonstrations for network peering scenarios.
-
-## Create Transit Network
-
-This operation will create the resources necessary for a transit network model with two VPCs; one acting as a public internet-facing DMZ where bastion servers and other internet resources could exist, and another that acts as an entirely private network with no internet access.  These networks are configured with security groups and routing rules that allow traffic between the two VPCs and their subnets through the transit gateway.  Once deployed, you can SSH in to the bastion host in order to can access to the host on the private network.
-
-### Variables
-
-The following variables are used during deployment and can be configured as extra vars at deploy time if you require something other than the defaults.
-
-#### Required
+Create or delete a hub-and-spoke transit gateway VPC network model in AWS: a public-facing DMZ VPC (with a bastion host) and a private VPC, both attached to a transit gateway, with security groups and routing rules allowing traffic between them through the gateway.
 
 ```yaml
----
+- name: Create Transit Networking Model
+  ansible.builtin.include_role:
+    name: demo.cloud.manage_transit_peered_networks
+  vars:
+    manage_transit_peered_networks_operation: create
+```
+
+Once deployed, SSH to the bastion host in the DMZ to reach hosts on the private network. Set `manage_transit_peered_networks_operation` to `create` or `delete` before including the role -- that value selects which task file runs. Resources below the transit gateway attachment (in the architecture diagram) demonstrate how additional VPCs could be connected the same way.
+
+Repo playbooks: [`cloud/create_transit_network.yml`](../../../../../../cloud/create_transit_network.yml), [`cloud/delete_transit_network.yml`](../../../../../../cloud/delete_transit_network.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: `localhost`
+- `amazon.aws` collection (VPC, subnet, security group, transit gateway, and EC2 resources)
+- AWS credentials with permission to create/delete VPCs, subnets, security groups, transit gateways/attachments, route tables, and EC2 instances
+- For `delete`: the same tags used at `create` time, so matching resources can be located and removed
+
+## Role Variables
+
+Defaults live in `defaults/main.yml`.
+
+### Required (caller-supplied, no default)
+
+```yaml
 aws_region: us-east-1 # The region in which the resources are deployed
-dmz_ssh_key_name: aws-test-key # The AWS SSH key to use when configuring access to the EC2 instances on the DMZ network.
-priv_network_ssh_key_name: aws-test-key # The AWS SSH key to use when configuring access to the EC2 instances on the private network.
-ssh_key_data: lookup('file', '~/.ssh/aws-test-key.pem') # The contents of the AWS SSH private key to store on the DMZ server for access to private network servers
+dmz_ssh_key_name: aws-test-key # The AWS SSH key to use when configuring access to the EC2 instances on the DMZ network
+priv_network_ssh_key_name: aws-test-key # The AWS SSH key to use when configuring access to the EC2 instances on the private network
+ssh_key_data: "{{ lookup('file', '~/.ssh/aws-test-key.pem') }}" # The contents of the AWS SSH private key to store on the DMZ server for access to private network servers
 ```
 
-#### Optional
+### Optional
 
-```yaml
----
-# These variables can be configured to change the VPC networks and the EC2 instances deployed into them.
-tenancy: default
-vpc_priv_net_cidr: 10.0.0.0/16
-vpc_priv_net_priv_subnet_cidr: 10.0.0.0/24
-vpc_priv_net_hosts_pattern: 10.0.*
-vpc_dmz_cidr: 10.1.0.0/16
-vpc_dmz_subnet1_cidr: 10.1.0.0/24
-dmz_instance_type: t2.micro
-dmz_instance_name: dmz-ssh-tunnel-vm
-dmz_instance_ami_owner: "{{ omit }}"
-dmz_instance_ami_architecture: x86_64
-dmz_instance_ami_filter: RHEL-8*HVM-*Hourly*
-dmz_instance_ami: undef # use this variable to override the AMI lookup
-priv_network_instance_type: t2.micro
-priv_network_instance_name: priv-network-vm
-priv_network_instance_ami_owner: "{{ omit }}"
-priv_network_instance_ami_architecture: x86_64
-priv_network_instance_ami_filter: RHEL-8*HVM-*Hourly*
-priv_network_instance_name: priv-network-vm
-priv_natwork_instance_ami: undef # use this variable to override the AMI lookup
-ansible_ssh_private_key_file_local_path: ~/.ssh/aws-test-key.pem # Must exist locally or be mapped in an EE
-ansible_ssh_private_key_file_dest_path: ~/.ssh/aws-test-key.pem
-priv_network_ssh_user: ec2-user
+| Variable | Default | Description |
+| --- | --- | --- |
+| `tenancy` | `default` | EC2 tenancy for both VPCs' instances |
+| `vpc_priv_net_cidr` | `10.0.0.0/16` | Private VPC CIDR |
+| `vpc_priv_net_public_subnet_cidr` | `10.0.0.0/24` | Private VPC's public-facing subnet CIDR |
+| `vpc_priv_net_priv_subnet_cidr` | `10.0.1.0/24` | Private VPC's private subnet CIDR |
+| `vpc_priv_net_hosts_pattern` | `10.0.*` | Host pattern used by the caller's SSH config for the private network |
+| `vpc_dmz_cidr` | `10.1.0.0/16` | DMZ VPC CIDR |
+| `vpc_dmz_subnet1_cidr` | `10.1.0.0/24` | DMZ VPC subnet CIDR |
+| `dmz_instance_type` | `t2.micro` | Instance type for the DMZ bastion |
+| `dmz_instance_name` | `dmz-ssh-tunnel-vm` | Name tag for the DMZ bastion |
+| `dmz_instance_ami_owner` | `{{ omit }}` | AMI owner filter for the DMZ bastion |
+| `dmz_instance_ami_architecture` | `x86_64` | AMI architecture filter for the DMZ bastion |
+| `dmz_instance_ami_filter` | `RHEL-8*HVM-*Hourly*` | AMI name filter for the DMZ bastion |
+| `dmz_instance_ami` | unset | Override to skip the AMI lookup entirely |
+| `priv_network_instance_type` | `t2.micro` | Instance type for the private-network VM |
+| `priv_network_instance_name` | `priv-network-vm` | Name tag for the private-network VM |
+| `priv_network_instance_ami_owner` | `{{ omit }}` | AMI owner filter for the private-network VM |
+| `priv_network_instance_ami_architecture` | `x86_64` | AMI architecture filter for the private-network VM |
+| `priv_network_instance_ami_filter` | `RHEL-8*HVM-*Hourly*` | AMI name filter for the private-network VM |
+| `priv_natwork_instance_ami` | unset | Override to skip the AMI lookup entirely (note: variable name as shipped) |
+| `transit_gateway_asn` | `64514` | ASN assigned to the transit gateway |
+| `transit_gateway_auto_associate` | `true` | Whether attachments auto-associate with the default route table |
+| `transit_gateway_auto_propagate` | `true` | Whether attachments auto-propagate routes to the default route table |
+| `transit_gateway_dns_support` | `true` | Whether DNS support is enabled on the transit gateway |
+| `ansible_ssh_private_key_file_local_path` | `~/.ssh/aws-test-key.pem` | Local path to the SSH private key (must exist locally or be mapped in an EE) |
+| `ansible_ssh_private_key_file_dest_path` | `~/.ssh/aws-test-key.pem` | Path on the DMZ bastion where the private key is written for reaching the private network |
+| `priv_network_ssh_user` | `ec2-user` | SSH user on the private-network VM |
 
-```
+## Infrastructure
 
-### Infrastructure
-
-The following AWS infrastructure resources are created during this deployment.  Each resource is configured with a set of tags that are used to determine if resources already exist, and which resources to clean up if the `delete` operation is run.
+The following AWS infrastructure resources are created during `create` and removed during `delete`. Each resource is tagged so the role can determine whether resources already exist, and which resources to clean up.
 
 ### Architecture Diagram
 
-![Deployment Architecture Diagram](./files/transit_network_arch_diagram.png)
+![Deployment Architecture Diagram](files/transit_network_arch_diagram.png)
 
 Resources below the dotted line demonstrate how you may connect other resources to the VPCs through a transit gateway attachment.
+
+## Entry points
+
+The role always runs `tasks/main.yml`, which validates `manage_transit_peered_networks_operation` and includes one of the files below:
+
+| Entry point | Description |
+| --- | --- |
+| `create` | Create both VPCs, subnets, security groups, transit gateway and attachments, routing, and the DMZ/private-network EC2 instances. |
+| `delete` | Tear down the transit gateway attachments/gateway, EC2 instances, security groups, subnets, and VPCs created by `create`. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.cloud`](../../README.md) for the AWS transit networking demos in this repository.

--- a/collections/ansible_collections/demo/cloud/roles/reports/README.md
+++ b/collections/ansible_collections/demo/cloud/roles/reports/README.md
@@ -10,7 +10,7 @@ Create an S3-hosted static website bucket, sync a local report directory into it
 
 `tasks/main.yml` always creates/configures the bucket and syncs `files/`, then dynamically includes `{{ reports_aws_report }}.yml` (`vpc` by default) to build the report-specific content before uploading `index.html`.
 
-This role is not currently referenced by a top-level repo playbook; it is invoked directly via `demo.cloud.reports` when a VPC report is needed (see the `Cloud / AWS | VPC Report` job template).
+This role is not currently referenced by any repo playbook or job template. The active `Cloud | AWS | VPC Report` path uses [`cloud/cloud_report.yml`](../../../../../../cloud/cloud_report.yml) with `demo.cloud.retrieve_info` → `demo.cloud.template` → `demo.cloud.build_report_s3` instead. Kept for direct use or future wiring.
 
 ## Requirements
 

--- a/collections/ansible_collections/demo/cloud/roles/reports/README.md
+++ b/collections/ansible_collections/demo/cloud/roles/reports/README.md
@@ -1,0 +1,51 @@
+# demo.cloud.reports
+
+Create an S3-hosted static website bucket, sync a local report directory into it, publish a landing page, and (via the `vpc` entry point) render and upload a VPC infrastructure report.
+
+```yaml
+- name: Publish VPC report to S3
+  ansible.builtin.include_role:
+    name: demo.cloud.reports
+```
+
+`tasks/main.yml` always creates/configures the bucket and syncs `files/`, then dynamically includes `{{ reports_aws_report }}.yml` (`vpc` by default) to build the report-specific content before uploading `index.html`.
+
+This role is not currently referenced by a top-level repo playbook; it is invoked directly via `demo.cloud.reports` when a VPC report is needed (see the `Cloud / AWS | VPC Report` job template).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: `localhost`
+- `amazon.aws` collection (`s3_bucket`, `s3_object`, `s3_object_info`, `ec2_vpc_net_info`, `ec2_instance_info`, `ec2_vpc_igw_info`, `aws_caller_info`)
+- `community.aws` collection (`s3_website`, `s3_sync`)
+- AWS credentials with permission to create/configure S3 buckets and read VPC/EC2/IGW info
+
+## Role Variables
+
+Defaults live in `defaults/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `reports_aws_region` | `us-east-1` | Region for the S3 bucket and the AWS info lookups used by `vpc.yml` |
+| `reports_aws_staging_dir` | `{{ playbook_dir \| default('/tmp') }}` | Local directory where rendered HTML is staged before upload |
+| `reports_aws_bucket_prefix` | first 4 chars of `AWS_ACCESS_KEY_ID` (lowercased) | Used to derive a unique bucket name |
+| `reports_aws_bucket_name` | `{{ reports_aws_bucket_prefix }}-reports` | S3 bucket created/configured as a static website |
+| `reports_aws_bucket_permissions` | `public-read` | ACL/permission applied to uploaded objects |
+| `reports_aws_public_access` | all `false` (public) | `public_access` block passed to `s3_bucket` |
+| `reports_aws_report` | `vpc` | Report task file (`{{ reports_aws_report }}.yml`) included after the bucket/website is configured |
+| `reports_aws_instance_filters` | `{{ omit }}` | Optional filters for EC2 instance info lookups |
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Create/configure the report bucket and website, sync `files/`, then include `{{ reports_aws_report }}.yml`, upload the resulting `index.html`, and print the bucket URL. |
+| `vpc` | Gather VPC, EC2 instance, and Internet Gateway info for `reports_aws_region`, template `vpc-report.html`, and upload it to the bucket. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.cloud`](../../README.md) for the AWS VPC reporting demos in this repository.

--- a/collections/ansible_collections/demo/cloud/roles/retrieve_aws_instances_info/README.md
+++ b/collections/ansible_collections/demo/cloud/roles/retrieve_aws_instances_info/README.md
@@ -1,0 +1,38 @@
+# demo.cloud.retrieve_aws_instances_info
+
+Gather package/service facts and OS diagnostics from an EC2 instance, then verify the instance's public webserver (and OpenSCAP reports path) are reachable, for the cloud infrastructure report.
+
+```yaml
+- name: Load retrieve info role
+  ansible.builtin.include_role:
+    name: demo.cloud.retrieve_aws_instances_info
+```
+
+Runs against each EC2 instance itself (not `localhost`): it gathers `service_facts`, checks `/etc/motd` and `getenforce`, then delegates to `localhost` to look up the instance's EC2 info by private IP and probe `http://<public_dns>/` and `http://<public_dns>/oscap-reports/`.
+
+Repo playbook: [`cloud/cloud_report.yml`](../../../../../../cloud/cloud_report.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: an EC2 instance reachable by Ansible, with facts gathered (`ansible_default_ipv4.address`)
+- `amazon.aws` collection (`ec2_instance_info`)
+- AWS credentials available for the `delegate_to: localhost` lookup
+
+## Role Variables
+
+This role has no `defaults/main.yml`; it uses `reports_aws_region` (falling back to `aws_region`, then `us-east-1`) from the caller/other cloud roles.
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Gather service facts, SELinux status, and `/etc/motd` presence; look up the instance's EC2 info by private IP; verify the webserver and `/oscap-reports/` path respond over HTTP. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.cloud`](../../README.md) for the AWS cloud reporting demos in this repository.

--- a/collections/ansible_collections/demo/cloud/roles/retrieve_info/README.md
+++ b/collections/ansible_collections/demo/cloud/roles/retrieve_info/README.md
@@ -1,0 +1,44 @@
+# demo.cloud.retrieve_info
+
+Gather VPC, EC2 instance, and Internet Gateway information across every region in `ec2_regions`, storing each region's data as a per-region fact for later use by `demo.cloud.template`.
+
+```yaml
+- name: Load retrieve info role
+  ansible.builtin.include_role:
+    name: demo.cloud.retrieve_info
+```
+
+For each region, the role sets a fact named after the region (dashes replaced with underscores, for example `us_east_1`) containing `vpc_info`, `ec2_instance_info`, and `igw_info`, and appends it to `all_ec2_regions`. It also records the AWS caller identity (`aws_user`) and the local `boto3` version.
+
+Repo playbook: [`cloud/cloud_report.yml`](../../../../../../cloud/cloud_report.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: `localhost` (all AWS lookups are `delegate_to: localhost`)
+- `amazon.aws` collection (`ec2_vpc_net_info`, `ec2_instance_info`, `ec2_vpc_igw_info`, `aws_caller_info`)
+- `boto3` importable by the Ansible controller's Python interpreter (queried via `pip` check mode and a `pipe` lookup)
+- AWS credentials with read access to VPCs, EC2 instances, and Internet Gateways in each configured region
+
+## Role Variables
+
+Defaults live in `defaults/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `ec2_regions` | ~20 regions (`us-east-1`, `us-west-2`, `eu-west-1`, etc.; several regions commented out) | Regions iterated over to build `all_ec2_regions` |
+| `filter_tag` | unset | Optional `ec2_instance_info` filter dict, applied per region |
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | For each region in `ec2_regions`, gather VPC/EC2/IGW info and store it as a per-region fact; also records `aws_user` and the local `boto3` version. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.cloud`](../../README.md) for the AWS cloud reporting demos in this repository.

--- a/collections/ansible_collections/demo/cloud/roles/template/README.md
+++ b/collections/ansible_collections/demo/cloud/roles/template/README.md
@@ -1,11 +1,45 @@
-# network.toolkit.build_report
+# demo.cloud.template
 
-To use this multi-platform network automation build_report role:
+Render the multi-region cloud infrastructure HTML report (`index.html`) from the per-region facts gathered by `demo.cloud.retrieve_info`, and copy its CSS/image assets alongside it.
 
-## Task example:
-
+```yaml
+- name: Template report into HTML
+  ansible.builtin.include_role:
+    name: demo.cloud.template
 ```
-- name: build a report
-  include_role:
-    name: build_report
-```
+
+Run after `demo.cloud.retrieve_info` (so `all_ec2_regions` and the per-region facts exist) and before `demo.cloud.build_report_linux` / `demo.cloud.build_report_s3` (so there is an `index.html` to publish).
+
+Repo playbook: [`cloud/cloud_report.yml`](../../../../../../cloud/cloud_report.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: `localhost` (all tasks are `delegate_to: localhost`, `run_once: true`)
+- Per-region facts populated by `demo.cloud.retrieve_info`
+
+## Role Variables
+
+Defaults live in `vars/main.yml`. These are largely shared boilerplate with the network/Linux report roles and are not all used by this role's own template.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `file_path` | `/var/www/html/` | Unused by this role's own tasks (destination is always `{{ playbook_dir }}/index.html`); kept from the shared vars file |
+| `web_host` | `ansible-1` | Unused by this role's own tasks |
+| `web_port` | `8088` | Unused by this role's own tasks |
+| `vendor` | `{ios: Cisco, nxos: Cisco, iosxr: Cisco, junos: Juniper, eos: Arista}` | Unused by this role's own tasks |
+| `transport` | `{cliconf: network_cli, netconf: netconf, httpapi: httpapi}` | Unused by this role's own tasks |
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Template `report.j2` to `{{ playbook_dir }}/index.html` and copy the role's `files/` (CSS, logos) alongside it. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.cloud`](../../README.md) for the AWS cloud reporting demos in this repository.

--- a/collections/ansible_collections/demo/compliance/README.md
+++ b/collections/ansible_collections/demo/compliance/README.md
@@ -1,6 +1,6 @@
 # demo.compliance
 
-Local collection containing roles used by the compliance demos in ansible-product-demos.
+Local collection containing roles used by the compliance demos in ansible-product-demos ([`linux/disa_stig.yml`](../../../../linux/disa_stig.yml), [`network/compliance.yml`](../../../../network/compliance.yml), [`windows/compliance.yml`](../../../../windows/compliance.yml)).
 
 This collection is not published to Ansible Galaxy or Automation Hub; it exists solely to organize roles used by playbooks in this repository under the `demo.compliance` namespace.
 
@@ -10,8 +10,8 @@ This collection is not published to Ansible Galaxy or Automation Hub; it exists 
 
 | Role | Description |
 |------|-------------|
-| [iosxeSTIG](roles/iosxeSTIG/) | Apply DISA STIG remediation rules to Cisco IOS-XE network devices. |
-| [rhel7STIG](roles/rhel7STIG/) | Apply DISA STIG remediation rules to RHEL 7 hosts. |
-| [rhel8STIG](roles/rhel8STIG/) | Apply DISA STIG remediation rules to RHEL 8 hosts. |
-| [rhel9STIG](roles/rhel9STIG/) | Apply DISA STIG remediation rules to RHEL 9 hosts. |
-| [win2022STIG](roles/win2022STIG/) | Apply DISA STIG remediation rules to Windows Server 2022 hosts. |
+| [iosxeSTIG](roles/iosxeSTIG/README.md) | Apply DISA STIG remediation rules to Cisco IOS-XE network devices. |
+| [rhel7STIG](roles/rhel7STIG/README.md) | Apply DISA STIG remediation rules to RHEL 7 hosts. |
+| [rhel8STIG](roles/rhel8STIG/README.md) | Apply DISA STIG remediation rules to RHEL 8 hosts. |
+| [rhel9STIG](roles/rhel9STIG/README.md) | Apply DISA STIG remediation rules to RHEL 9 hosts. |
+| [win2022STIG](roles/win2022STIG/README.md) | Apply DISA STIG remediation rules to Windows Server 2022 hosts. |

--- a/collections/ansible_collections/demo/compliance/README.md
+++ b/collections/ansible_collections/demo/compliance/README.md
@@ -1,0 +1,17 @@
+# demo.compliance
+
+Local collection containing roles used by the compliance demos in ansible-product-demos.
+
+This collection is not published to Ansible Galaxy or Automation Hub; it exists solely to organize roles used by playbooks in this repository under the `demo.compliance` namespace.
+
+## Contents
+
+### Roles
+
+| Role | Description |
+|------|-------------|
+| [iosxeSTIG](roles/iosxeSTIG/) | Apply DISA STIG remediation rules to Cisco IOS-XE network devices. |
+| [rhel7STIG](roles/rhel7STIG/) | Apply DISA STIG remediation rules to RHEL 7 hosts. |
+| [rhel8STIG](roles/rhel8STIG/) | Apply DISA STIG remediation rules to RHEL 8 hosts. |
+| [rhel9STIG](roles/rhel9STIG/) | Apply DISA STIG remediation rules to RHEL 9 hosts. |
+| [win2022STIG](roles/win2022STIG/) | Apply DISA STIG remediation rules to Windows Server 2022 hosts. |

--- a/collections/ansible_collections/demo/compliance/galaxy.yml
+++ b/collections/ansible_collections/demo/compliance/galaxy.yml
@@ -1,0 +1,17 @@
+---
+namespace: demo
+name: compliance
+version: 1.0.0+08062601
+readme: README.md
+authors:
+  - Ansible Product Demos (https://github.com/ansible/product-demos)
+description: Roles supporting STIG compliance automation demos in ansible-product-demos.
+license:
+  - GPL-3.0-or-later
+tags:
+  - apd
+  - compliance
+  - security
+repository: https://github.com/ansible/product-demos
+issues: https://github.com/ansible/product-demos/issues
+...

--- a/collections/ansible_collections/demo/compliance/meta/runtime.yml
+++ b/collections/ansible_collections/demo/compliance/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: ">=2.16.0"

--- a/collections/ansible_collections/demo/compliance/roles/iosxeSTIG/README.md
+++ b/collections/ansible_collections/demo/compliance/roles/iosxeSTIG/README.md
@@ -1,0 +1,61 @@
+# demo.compliance.iosxeSTIG
+
+Remediate a Cisco IOS XE device against the DISA STIG for Cisco IOS XE Router NDM/RTR (`U_Cisco_IOS-XE_Router_NDM_STIG_V2R1` and `..._RTR_STIG_V2R1`, 33 rules), driven entirely by `ios_config`/`ios_command`.
+
+```yaml
+- name: IOS XE Compliance
+  hosts: "{{ _hosts | default('ios') }}"
+  vars:
+    ignore_all_errors: false
+    ansible_command_timeout: 60
+  roles:
+    - demo.compliance.iosxeSTIG
+```
+
+Every rule is gated by its own `iosxeSTIG_stigrule_<ID>_Manage` boolean (default `true`, except a few site-specific rules noted below) plus companion `_Lines`/`_Text` variables holding the config to enforce. Rules are tagged `stigrule_<ID>` for selective runs (`--tags`). All tasks run with `ignore_errors: "{{ ignore_all_errors }}"`, a variable the role does **not** default -- the caller must set it. A `save configuration` handler (`write memory`) fires when any task changes state, but only runs if `iosxeSTIG_save_configuration_Manage` is `true` (default `false`).
+
+The role ships a whitelist-required `stig_xml` callback plugin (`callback_plugins/stig_xml.py`) that watches for tasks named `stigrule_<ID>...`, maps `changed` to XCCDF fail / `ok` to pass, and writes an XCCDF `TestResult` XML against the shipped benchmark (`files/*.xml`, or `STIG_PATH`) to `XML_PATH` (or a temp file) when enabled (for example `ANSIBLE_CALLBACKS_ENABLED=stig_xml`).
+
+Repo playbook: [`network/compliance.yml`](../../../../../../network/compliance.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: Cisco IOS XE device reachable via `network_cli`
+- `cisco.ios` collection
+- Caller must set `ignore_all_errors` (used by every task); the repo playbook sets it to `false`
+
+## Role Variables
+
+Defaults live in `defaults/main.yml` (~102 variables). Each of the 33 STIG rules has an `iosxeSTIG_stigrule_<ID>_Manage` toggle plus rule-specific value variables (`_Lines`, `_Text`, etc.); see that file for the complete list. Site-specific rules default to **disabled** since they require environment-specific values:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `iosxeSTIG_stigrule_215826_Manage` | `false` | Password policy enforcement (site-specific) |
+| `iosxeSTIG_stigrule_215837_Manage` | `false` | Central logging host configuration (site-specific) |
+| `iosxeSTIG_stigrule_215838_Manage` | `false` | NTP server configuration (site-specific) |
+| `iosxeSTIG_save_configuration_Manage` | `false` | Whether the `save configuration` handler runs `write memory` after changes |
+
+Example of a typical rule pair:
+
+```yaml
+iosxeSTIG_stigrule_215814_Manage: true
+iosxeSTIG_stigrule_215814_login_Text: |
+  banner login ^C
+  ... DoD warning banner text ...
+  ^C
+```
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Apply each enabled STIG rule via `ios_config`/`ios_command`, tagged `stigrule_<ID>`; notify `save configuration` on change. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.compliance`](../../README.md) for the network compliance demos in this repository.

--- a/collections/ansible_collections/demo/compliance/roles/rhel7STIG/README.md
+++ b/collections/ansible_collections/demo/compliance/roles/rhel7STIG/README.md
@@ -1,0 +1,52 @@
+# demo.compliance.rhel7STIG
+
+Remediate a RHEL 7 host against the DISA STIG for Red Hat Enterprise Linux 7 (`U_RHEL_7_STIG_V3R10`, 144 rules) -- banners, `dconf`/screensaver locks, `sysctl` hardening, package removal, service state, and audit configuration.
+
+```yaml
+- name: Run Compliance Profile
+  ansible.builtin.include_role:
+    name: "demo.compliance.rhel{{ ansible_distribution_major_version }}STIG"
+```
+
+Every rule is gated by its own `rhel7STIG_stigrule_<ID>_Manage` boolean (default `true` for all but 2 site-specific rules) plus companion value variables (`_Value`, `_Line`, `_Content`, `_Dest`, etc.). Rules are tagged `stigrule_<ID>` for selective runs (`--tags`). Handlers (`dconf_update`, `auditd_restart`, `ssh_restart`, `do_reboot`) fire on the relevant config changes.
+
+The role ships a whitelist-required `stig_xml` callback plugin (`callback_plugins/stig_xml.py`) that watches for tasks named `stigrule_<ID>...`, maps `changed` to XCCDF fail / `ok` to pass, and writes an XCCDF `TestResult` XML against the shipped benchmark (`files/U_RHEL_7_STIG_V3R10_Manual-xccdf.xml`, or `STIG_PATH`) to `XML_PATH` (or a temp file) when enabled (for example `ANSIBLE_CALLBACKS_ENABLED=stig_xml`).
+
+Repo playbook: [`linux/disa_stig.yml`](../../../../../../linux/disa_stig.yml) (selects `rhel{{ ansible_distribution_major_version }}STIG` dynamically).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: RHEL 7 host with `become`
+- `community.general` collection (`ini_file`, and others used by `lineinfile`/`sysctl`/`yum` task equivalents)
+
+## Role Variables
+
+Defaults live in `defaults/main.yml` (~327 variables). Each of the 144 STIG rules has an `rhel7STIG_stigrule_<ID>_Manage` toggle plus rule-specific value variables; see that file for the complete list. Two rules default to **disabled**:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `rhel7STIG_stigrule_204509_Manage` | `false` | Disabled by default (site-specific) |
+| `rhel7STIG_stigrule_204624_Manage` | `false` | Disabled by default (site-specific) |
+
+Example of a typical rule pair:
+
+```yaml
+rhel7STIG_stigrule_204393_Manage: true
+rhel7STIG_stigrule_204393__etc_dconf_db_local_d_01_banner_message_Value: |
+  ... DoD warning banner text ...
+```
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Apply each enabled STIG rule (`lineinfile`, `ini_file`, `sysctl`, `yum`, `service`, `shell`, `copy`), tagged `stigrule_<ID>`; notify the relevant handler on change. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.compliance`](../../README.md) for the Linux compliance demos in this repository.

--- a/collections/ansible_collections/demo/compliance/roles/rhel8STIG/README.md
+++ b/collections/ansible_collections/demo/compliance/roles/rhel8STIG/README.md
@@ -1,0 +1,48 @@
+# demo.compliance.rhel8STIG
+
+Remediate a RHEL 8 host against the DISA STIG for Red Hat Enterprise Linux 8 (`U_RHEL_8_STIG_V2R3`, 171 rules) -- banners, password/crypto policy, package removal, `sysctl`/SELinux hardening, service state, and audit/rsyslog configuration.
+
+```yaml
+- name: Run Compliance Profile
+  ansible.builtin.include_role:
+    name: "demo.compliance.rhel{{ ansible_distribution_major_version }}STIG"
+```
+
+Every rule is gated by its own `rhel8STIG_stigrule_<ID>_Manage` boolean (default `true` for all rules) plus companion value variables (`_Value`, `_Line`, `_State`, etc.). Rules are tagged `stigrule_<ID>` for selective runs (`--tags`). Handlers (`dconf_update`, `auditd_restart`, `ssh_restart`, `rsyslog_restart`, `sysctl_load_settings`, `daemon_reload`, `networkmanager_reload`, `logind_restart`, `with_faillock_enable`, `do_reboot`) fire on the relevant config changes.
+
+The role ships a whitelist-required `stig_xml` callback plugin (`callback_plugins/stig_xml.py`) that watches for tasks named `stigrule_<ID>...`, maps `changed` to XCCDF fail / `ok` to pass, and writes an XCCDF `TestResult` XML against the shipped benchmark (`files/U_RHEL_8_STIG_V2R3_Manual-xccdf.xml`, or `STIG_PATH`) to `XML_PATH` (or a temp file) when enabled (for example `ANSIBLE_CALLBACKS_ENABLED=stig_xml`).
+
+Repo playbook: [`linux/disa_stig.yml`](../../../../../../linux/disa_stig.yml) (selects `rhel{{ ansible_distribution_major_version }}STIG` dynamically).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: RHEL 8 host with `become`
+
+## Role Variables
+
+Defaults live in `defaults/main.yml` (~370 variables). Each of the 171 STIG rules has an `rhel8STIG_stigrule_<ID>_Manage` toggle (all default `true`) plus rule-specific value variables; see that file for the complete list.
+
+Example of a typical rule pair:
+
+```yaml
+rhel8STIG_stigrule_230239_Manage: true
+rhel8STIG_stigrule_230239_krb5_workstation_State: removed
+
+rhel8STIG_stigrule_230240_Manage: true
+rhel8STIG_stigrule_230240_SELINUX_Value: enforcing
+```
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Apply each enabled STIG rule (`lineinfile`, `yum`, `sysctl`, `ini_file`, `service`, `shell`, `systemd_service`, `copy`), tagged `stigrule_<ID>`; notify the relevant handler on change. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.compliance`](../../README.md) for the Linux compliance demos in this repository.

--- a/collections/ansible_collections/demo/compliance/roles/rhel9STIG/README.md
+++ b/collections/ansible_collections/demo/compliance/roles/rhel9STIG/README.md
@@ -1,0 +1,48 @@
+# demo.compliance.rhel9STIG
+
+Remediate a RHEL 9 host against the DISA STIG for Red Hat Enterprise Linux 9 (`U_RHEL_9_STIG_V2R4`, 286 rules) -- banners, `systemd-journald`/audit configuration, `sysctl` kernel hardening, GRUB/boot file permissions, package removal, and service state. The largest role in the collection.
+
+```yaml
+- name: Run Compliance Profile
+  ansible.builtin.include_role:
+    name: "demo.compliance.rhel{{ ansible_distribution_major_version }}STIG"
+```
+
+Every rule is gated by its own `rhel9STIG_stigrule_<ID>_Manage` boolean (default `true` for all rules) plus companion value variables (`_Value`, `_Line`, `_Dest`, `_Content`, etc.). Rules are tagged `stigrule_<ID>` for selective runs (`--tags`). Handlers (`dconf_update`, `auditd_restart`, `ssh_restart`, `rsyslog_restart`, `sysctl_load_settings`, `daemon_reload`, `networkmanager_reload`, `logind_restart`, `with_faillock_enable`, `do_reboot`) fire on the relevant config changes.
+
+The role ships a whitelist-required `stig_xml` callback plugin (`callback_plugins/stig_xml.py`) that watches for tasks named `stigrule_<ID>...`, maps `changed` to XCCDF fail / `ok` to pass, and writes an XCCDF `TestResult` XML against the shipped benchmark (`files/U_RHEL_9_STIG_V2R4_Manual-xccdf.xml`, or `STIG_PATH`) to `XML_PATH` (or a temp file) when enabled (for example `ANSIBLE_CALLBACKS_ENABLED=stig_xml`).
+
+Repo playbook: [`linux/disa_stig.yml`](../../../../../../linux/disa_stig.yml) (selects `rhel{{ ansible_distribution_major_version }}STIG` dynamically).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: RHEL 9 host with `become`
+
+## Role Variables
+
+Defaults live in `defaults/main.yml` (~683 variables). Each of the 286 STIG rules has an `rhel9STIG_stigrule_<ID>_Manage` toggle (all default `true`) plus rule-specific value variables; see that file for the complete list.
+
+Example of a typical rule pair:
+
+```yaml
+rhel9STIG_stigrule_257785_Manage: true
+rhel9STIG_stigrule_257785_ctrl_alt_del_target_State: masked
+
+rhel9STIG_stigrule_257786_Manage: true
+rhel9STIG_stigrule_257786_debug_shell_State: masked
+```
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Apply each enabled STIG rule (`lineinfile`, `shell`, `file`, `yum`, `sysctl`, `service`, `ini_file`, `systemd_service`, `copy`), tagged `stigrule_<ID>`; notify the relevant handler on change. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.compliance`](../../README.md) for the Linux compliance demos in this repository.

--- a/collections/ansible_collections/demo/compliance/roles/win2022STIG/README.md
+++ b/collections/ansible_collections/demo/compliance/roles/win2022STIG/README.md
@@ -1,0 +1,59 @@
+# demo.compliance.win2022STIG
+
+Remediate a Windows Server 2022 host against the DISA STIG for Microsoft Windows Server 2022 (`U_MS_Windows_Server_2022_STIG_V1R1`, 198 rules) -- registry settings, audit policy, user rights assignments, security policy, ACLs, and Windows feature state.
+
+```yaml
+- name: STIG a Windows 2022 Server
+  hosts: "{{ HOSTS | default('os_windows') }}"
+  vars:
+    win2022STIG_stigrule_254269_Manage: false  # noqa var-naming
+    win2022STIG_stigrule_254276_Manage: false  # noqa var-naming
+  tasks:
+    - name: Include win2022STIG role
+      ansible.builtin.include_role:
+        name: demo.compliance.win2022STIG
+```
+
+Every rule is gated by its own `win2022STIG_stigrule_<ID>_Manage` boolean (177 default `true`, 21 default `false` for site-specific rules -- for example NTP and account lockout/password policy) plus companion value variables. Rules are tagged `stigrule_<ID>` for selective runs (`--tags`). This role's `handlers/main.yml` is empty -- registry/policy modules apply changes directly, with no separate restart/reload step.
+
+The role ships a whitelist-required `stig_xml` callback plugin (`callback_plugins/stig_xml.py`) that watches for tasks named `stigrule_<ID>...`, maps `changed` to XCCDF fail / `ok` to pass, and writes an XCCDF `TestResult` XML against the shipped benchmark (`files/U_MS_Windows_Server_2022_STIG_V1R1_Manual-xccdf.xml`, or `STIG_PATH`) to `XML_PATH` (or a temp file) when enabled (for example `ANSIBLE_CALLBACKS_ENABLED=stig_xml`).
+
+Repo playbook: [`windows/compliance.yml`](../../../../../../windows/compliance.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: Windows Server 2022 host reachable over WinRM
+- `ansible.windows` collection (`win_regedit`, `win_audit_policy_system`, `win_user_right`, `win_security_policy`, `win_acl`, `win_feature`)
+
+## Role Variables
+
+Defaults live in `defaults/main.yml` (~732 variables). Each of the 198 STIG rules has a `win2022STIG_stigrule_<ID>_Manage` toggle plus rule-specific value variables (registry key/value/type, user lists, etc.); see that file for the complete list. Site-specific rules default to **disabled**, for example:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `win2022STIG_stigrule_254281_Manage` | `false` | DoD-provided NTP server configuration (site-specific placeholder) |
+| Various account lockout / password policy rules (`254285`-`254293`) | `false` | Site-specific policy values |
+
+Example of a typical rule pair:
+
+```yaml
+win2022STIG_stigrule_254276_Manage: true
+win2022STIG_stigrule_254276_SMB1_Key: HKLM:\SYSTEM\CurrentControlSet\Services\mrxsmb10
+win2022STIG_stigrule_254276_SMB1_ValueData: 4
+win2022STIG_stigrule_254276_SMB1_ValueType: dword
+```
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Apply each enabled STIG rule (`win_regedit`, `win_audit_policy_system`, `win_user_right`, `win_security_policy`, `win_acl`, `win_feature`), tagged `stigrule_<ID>`. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.compliance`](../../README.md) for the Windows compliance demos in this repository.

--- a/collections/ansible_collections/demo/openshift/roles/cluster_config/README.md
+++ b/collections/ansible_collections/demo/openshift/roles/cluster_config/README.md
@@ -16,7 +16,7 @@ Repo playbook: [`openshift/cnv/install.yml`](../../../../../../openshift/cnv/ins
 
 ## Requirements
 
-- Ansible 2.14+
+- ansible-core >= 2.16.0
 - Target: OpenShift cluster access
 - `redhat.openshift` and `kubernetes.core` collections
 - An attached "OpenShift Credential" (type `OpenShift or Kubernetes API Bearer Token`) so `K8S_AUTH_HOST` / `K8S_AUTH_API_KEY` / `K8S_AUTH_VERIFY_SSL` are injected

--- a/collections/ansible_collections/demo/openshift/roles/eda_controller/README.md
+++ b/collections/ansible_collections/demo/openshift/roles/eda_controller/README.md
@@ -16,7 +16,7 @@ Repo playbook: [`openshift/eda/install.yml`](../../../../../../openshift/eda/ins
 
 ## Requirements
 
-- Ansible 2.9+
+- ansible-core >= 2.16.0
 - Target: OpenShift cluster access with the AAP EDA operator available (typically already installed in the AAP namespace)
 - `kubernetes.core` collection
 - An attached "OpenShift Credential" (type `OpenShift or Kubernetes API Bearer Token`) so `K8S_AUTH_HOST` / `K8S_AUTH_API_KEY` / `K8S_AUTH_VERIFY_SSL` are injected

--- a/collections/ansible_collections/demo/openshift/roles/snapshot/README.md
+++ b/collections/ansible_collections/demo/openshift/roles/snapshot/README.md
@@ -20,7 +20,7 @@ Repo playbook: [`openshift/cnv/snapshot.yml`](../../../../../../openshift/cnv/sn
 
 ## Requirements
 
-- Ansible 2.14+
+- ansible-core >= 2.16.0
 - Target: OpenShift cluster with OpenShift Virtualization (CNV) installed
 - `kubernetes.core` and `redhat.openshift_virtualization` collections
 - An attached "OpenShift Credential" (type `OpenShift or Kubernetes API Bearer Token`) so `K8S_AUTH_HOST` / `K8S_AUTH_API_KEY` / `K8S_AUTH_VERIFY_SSL` are injected

--- a/collections/ansible_collections/demo/openshift/roles/vault/README.md
+++ b/collections/ansible_collections/demo/openshift/roles/vault/README.md
@@ -21,7 +21,7 @@ Repo playbook: [`openshift/vault.yml`](../../../../../../openshift/vault.yml).
 
 ## Requirements
 
-- Ansible 2.14+
+- ansible-core >= 2.16.0
 - Target: OpenShift cluster access
 - `kubernetes.core` collection
 - `oc` and Helm CLI available to the controller

--- a/collections/ansible_collections/demo/patching/README.md
+++ b/collections/ansible_collections/demo/patching/README.md
@@ -1,0 +1,32 @@
+# demo.patching
+
+Local collection containing roles and modules used by the patching demos in ansible-product-demos.
+
+This collection is not published to Ansible Galaxy or Automation Hub; it exists solely to organize roles and modules used by playbooks in this repository under the `demo.patching` namespace.
+
+## Contents
+
+### Roles
+
+| Role | Description |
+|------|-------------|
+| [build_report_network](roles/build_report_network/README.md) | Install Apache and build an HTML report from network device facts. |
+| [build_report_windows](roles/build_report_windows/README.md) | Install Apache and build an HTML report from Windows services and packages facts. |
+| [build_report_windows_patch](roles/build_report_windows_patch/README.md) | Install Apache and build an HTML report from Windows update job facts. |
+| [patch_linux](roles/patch_linux/) | Upgrade packages via `yum`/`dnf`, then reboot if required. |
+| [patch_windows](roles/patch_windows/) | Scan installed packages/services, then apply Windows Updates. |
+| [report_linux](roles/report_linux/README.md) | Install Apache and build an HTML report from Linux services and packages facts. |
+| [report_linux_patching](roles/report_linux_patching/README.md) | Install Apache and build an HTML report from Linux patching results (yum/dnf). |
+| [report_ocp_patching](roles/report_ocp_patching/README.md) | Build an HTML patching report for OpenShift-hosted patching workflows. |
+| [report_server](roles/report_server/) | Configure the report landing page and web server (Apache on Linux, IIS on Windows). |
+| [report_windows](roles/report_windows/README.md) | Install Apache and build an HTML report from Windows services and packages facts. |
+| [report_windows_patching](roles/report_windows_patching/README.md) | Install Apache and build an HTML report from Windows patching job facts. |
+
+### Modules
+
+| Module | Description |
+|--------|-------------|
+| [scan_packages](plugins/modules/scan_packages.py) | Return installed packages information as fact data. |
+| [scan_services](plugins/modules/scan_services.py) | Return service state information as fact data. |
+| [win_scan_packages](plugins/modules/win_scan_packages.py) | Return Windows package state information as fact data. |
+| [win_scan_services](plugins/modules/win_scan_services.py) | Return Windows service state information as fact data. |

--- a/collections/ansible_collections/demo/patching/README.md
+++ b/collections/ansible_collections/demo/patching/README.md
@@ -13,12 +13,12 @@ This collection is not published to Ansible Galaxy or Automation Hub; it exists 
 | [build_report_network](roles/build_report_network/README.md) | Install Apache and build an HTML report from network device facts. |
 | [build_report_windows](roles/build_report_windows/README.md) | Install Apache and build an HTML report from Windows services and packages facts. |
 | [build_report_windows_patch](roles/build_report_windows_patch/README.md) | Install Apache and build an HTML report from Windows update job facts. |
-| [patch_linux](roles/patch_linux/) | Upgrade packages via `yum`/`dnf`, then reboot if required. |
-| [patch_windows](roles/patch_windows/) | Scan installed packages/services, then apply Windows Updates. |
+| [patch_linux](roles/patch_linux/README.md) | Upgrade packages via `yum`/`dnf`, then reboot if required. |
+| [patch_windows](roles/patch_windows/README.md) | Scan installed packages/services, then apply Windows Updates. |
 | [report_linux](roles/report_linux/README.md) | Install Apache and build an HTML report from Linux services and packages facts. |
 | [report_linux_patching](roles/report_linux_patching/README.md) | Install Apache and build an HTML report from Linux patching results (yum/dnf). |
 | [report_ocp_patching](roles/report_ocp_patching/README.md) | Build an HTML patching report for OpenShift-hosted patching workflows. |
-| [report_server](roles/report_server/) | Configure the report landing page and web server (Apache on Linux, IIS on Windows). |
+| [report_server](roles/report_server/README.md) | Configure the report landing page and web server (Apache on Linux, IIS on Windows). |
 | [report_windows](roles/report_windows/README.md) | Install Apache and build an HTML report from Windows services and packages facts. |
 | [report_windows_patching](roles/report_windows_patching/README.md) | Install Apache and build an HTML report from Windows patching job facts. |
 

--- a/collections/ansible_collections/demo/patching/galaxy.yml
+++ b/collections/ansible_collections/demo/patching/galaxy.yml
@@ -1,0 +1,18 @@
+---
+namespace: demo
+name: patching
+version: 1.0.0+08062601
+readme: README.md
+authors:
+  - Ansible Product Demos (https://github.com/ansible/product-demos)
+description: Roles and modules supporting patching and reporting demos in ansible-product-demos.
+license:
+  - GPL-3.0-or-later
+tags:
+  - apd
+  - patching
+  - linux
+  - windows
+repository: https://github.com/ansible/product-demos
+issues: https://github.com/ansible/product-demos/issues
+...

--- a/collections/ansible_collections/demo/patching/meta/runtime.yml
+++ b/collections/ansible_collections/demo/patching/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: ">=2.16.0"

--- a/collections/ansible_collections/demo/patching/roles/build_report_network/README.md
+++ b/collections/ansible_collections/demo/patching/roles/build_report_network/README.md
@@ -1,36 +1,49 @@
-build_report_network
-========
+# demo.patching.build_report_network
 
-Installs Apache and creates a report based on facts from network devices
+Build an HTML report of network device configuration (interfaces, LACP, VLANs, OSPF, BGP, static routes) from resource facts gathered by `cisco.ios`/`cisco.nxos`/`cisco.iosxr`, and copy it -- with shared CSS/logo assets -- to the report server's web root.
 
-Requirements
-------------
+Re-written from [network-automation/toolkit](https://github.com/network-automation/toolkit/blob/master/roles/build_report/tasks/main.yml).
 
-Must run on Apache server
-
-Role Variables / Configuration
---------------
-
-N/A
-
-Dependencies
-------------
-
-N/A
-
-Example Playbook
-----------------
-
-The role can be used to create an html report on any number of Linux hosts using any number of network devices
-
-
+```yaml
+- name: Build report server
+  ansible.builtin.include_role:
+    name: "{{ item }}"
+  loop:
+    - demo.patching.report_server
+    - demo.patching.build_report_network
 ```
----
-- hosts: all
 
-  tasks:
-  - name: Run Network Report
-    import_role:
-      name: shadowman.reports.build_report_network
+Run after `cisco.ios.ios_facts` / `cisco.nxos.nxos_facts` / `cisco.iosxr.iosxr_facts` have gathered `gather_network_resources: all`, and after `demo.patching.report_server` has created the report directory/web server.
 
-```
+Repo playbook: [`network/report.yml`](../../../../../../network/report.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: the report server (Linux/Apache), with `hostvars` available for the network devices reported on
+- Network resource facts already gathered for the devices being reported on (`cisco.ios`, `cisco.nxos`, and/or `cisco.iosxr` collections)
+
+## Role Variables
+
+Defaults live in `vars/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `file_path` | `{{ web_path \| default('/var/www/html/reports') }}` | Destination directory for `network.html`, CSS, and logo assets |
+| `vendor` | `{ios: Cisco, nxos: Cisco, iosxr: Cisco, junos: Juniper, eos: Arista}` | Maps `ansible_network_os` to a display vendor name in the report |
+| `transport` | `{cliconf: Network_CLI, netconf: NETCONF, nxapi: NX-API}` | Maps connection plugin to a display transport name in the report |
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Create the report directory, template `network.html` from gathered network resource facts, copy CSS and logo assets, and print the report URL. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.patching`](../../README.md) for the network reporting demos in this repository.
+- Adapted from [network-automation/toolkit](https://github.com/network-automation/toolkit).

--- a/collections/ansible_collections/demo/patching/roles/build_report_windows/README.md
+++ b/collections/ansible_collections/demo/patching/roles/build_report_windows/README.md
@@ -1,36 +1,39 @@
-build_report_windows
-========
+# demo.patching.build_report_windows
 
-Installs Apache and creates a report based on facts from Windows services and packages modules
+Build an HTML inventory report of a Windows host's installed packages and running services, and copy it -- with shared CSS/logo assets -- to the report server's web root.
 
-Requirements
-------------
-
-Must run on Apache server
-
-Role Variables / Configuration
---------------
-
-N/A
-
-Dependencies
-------------
-
-N/A
-
-Example Playbook
-----------------
-
-The role can be used to create an html report on any number of Linux hosts using any number of Windows servers about their services and packages installed
-
-
+```yaml
+- name: Build Windows inventory report
+  ansible.builtin.include_role:
+    name: demo.patching.build_report_windows
 ```
----
-- hosts: all
 
-  tasks:
-  - name: Run Windows Report
-    import_role:
-      name: shadowman.reports.build_report_windows
+Not currently referenced by a repo playbook; `demo.patching.report_windows` is the actively used equivalent (and correctly uses `ansible.windows.win_template` / `win_copy` rather than the Linux `ansible.builtin` modules used here). Kept for backward compatibility -- prefer `demo.patching.report_windows` for new work.
 
-```
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: as templated, a Windows web root (`C:\Inetpub\wwwroot`), but the tasks use `ansible.builtin.template` / `ansible.builtin.copy`, which only work against a POSIX-style connection to that path
+- Package/service facts populated (`ansible.builtin.package_facts` / `service_facts`)
+
+## Role Variables
+
+Defaults live in `vars/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `file_path` | `/var/www/html` | Destination directory for `windows.html`, CSS, and logo assets |
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Template `windows.html` from package/service facts, copy CSS and logo assets, and print the report URL. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.patching`](../../README.md) for the Windows patching report demos in this repository.

--- a/collections/ansible_collections/demo/patching/roles/build_report_windows_patch/README.md
+++ b/collections/ansible_collections/demo/patching/roles/build_report_windows_patch/README.md
@@ -1,36 +1,39 @@
-build_report_windows_patch
-========
+# demo.patching.build_report_windows_patch
 
-Installs Apache and creates a report based on facts from Windows update job
+Build an HTML patching report for a Windows host, and copy it -- with shared CSS/logo assets -- to the report server's web root.
 
-Requirements
-------------
-
-Must run on Apache server
-
-Role Variables / Configuration
---------------
-
-N/A
-
-Dependencies
-------------
-
-N/A
-
-Example Playbook
-----------------
-
-The role can be used to create an html patching report on any number of Linux hosts using any number of Windows servers
-
-
+```yaml
+- name: Build Windows patch report
+  ansible.builtin.include_role:
+    name: demo.patching.build_report_windows_patch
 ```
----
-- hosts: all
 
-  tasks:
-  - name: Run Windows Patch Report
-    import_role:
-      name: shadowman.reports.build_report_windows_patch
+Not currently referenced by a repo playbook; `demo.patching.report_windows_patching` is the actively used equivalent (and correctly uses `ansible.windows.win_template` / `win_copy` rather than the Linux `ansible.builtin` modules used here). Kept for backward compatibility -- prefer `demo.patching.report_windows_patching` for new work.
 
-```
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: as templated, a Windows web root (`C:\Inetpub\wwwroot`), but the tasks use `ansible.builtin.template` / `ansible.builtin.copy`, which only work against a POSIX-style connection to that path
+- A `patchresult` fact on the target host (`templates/report.j2` reads `hostvars[windows_host].patchresult`); note neither `demo.patching.patch_windows` (`patch_windows_patchingresult`) nor `demo.patching.report_windows_patching`'s template (`patchingresult`) use this exact name
+
+## Role Variables
+
+Defaults live in `vars/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `file_path` | `/var/www/html` | Destination directory for `windowspatch.html`, CSS, and logo asset |
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Template `windowspatch.html`, copy CSS and the logo asset, and print the report URL. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.patching`](../../README.md) for the Windows patching report demos in this repository.

--- a/collections/ansible_collections/demo/patching/roles/patch_linux/README.md
+++ b/collections/ansible_collections/demo/patching/roles/patch_linux/README.md
@@ -1,0 +1,42 @@
+# demo.patching.patch_linux
+
+Upgrade all packages on a RHEL host via `yum`/`dnf` (excluding a configurable package list) and reboot automatically if the kernel or a core library requires it.
+
+```yaml
+- name: Include patching role
+  ansible.builtin.include_role:
+    name: demo.patching.patch_linux
+```
+
+Package/service facts are gathered first (for later reporting by `demo.patching.report_linux` / `demo.patching.report_linux_patching`), then `needs-restarting -r` decides whether a reboot is required; the reboot only runs when `allow_reboot` is `true`.
+
+Repo playbooks: [`linux/patching.yml`](../../../../../../linux/patching.yml), [`openshift/cnv/patch.yml`](../../../../../../openshift/cnv/patch.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: RHEL host with `become` and either `yum` or `dnf`
+- `yum-utils` installed on the target (provides `needs-restarting`; the calling playbooks install it before running this role)
+
+## Role Variables
+
+Defaults live in `defaults/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `exclude_packages` | `authselect`, `authselect-compat`, `authselect-libs`, `fprintd-pam` | Packages excluded from the `yum`/`dnf` upgrade (`state: latest`) |
+| `allow_reboot` | `true` | When `true` and `needs-restarting -r` reports a pending reboot, the host is rebooted |
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Gather package/service facts, upgrade all packages (`yum` or `dnf`, excluding `exclude_packages`), check for a required reboot, and reboot if `allow_reboot` is `true`. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.patching`](../../README.md) for the Linux patching demos in this repository.

--- a/collections/ansible_collections/demo/patching/roles/patch_windows/README.md
+++ b/collections/ansible_collections/demo/patching/roles/patch_windows/README.md
@@ -1,0 +1,43 @@
+# demo.patching.patch_windows
+
+Scan installed packages and services (via the collection's `win_scan_packages` / `win_scan_services` modules), then install Windows Updates for the configured update categories.
+
+```yaml
+- name: Patch windows server
+  ansible.builtin.include_role:
+    name: demo.patching.patch_windows
+```
+
+The package/service scan populates fact data consumed later by `demo.patching.report_windows` / `demo.patching.report_windows_patching`. Reboots after patching are controlled by `allow_reboot`.
+
+Repo playbook: [`windows/patching.yml`](../../../../../../windows/patching.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: Windows host reachable over WinRM
+- `ansible.windows` collection (`win_updates`)
+- This collection's `win_scan_packages` and `win_scan_services` modules (`demo.patching`)
+
+## Role Variables
+
+Defaults live in `defaults/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `win_update_categories` | `Application`, `Connectors`, `CriticalUpdates`, `DefinitionUpdates`, `DeveloperKits`, `FeaturePacks Guidance`, `SecurityUpdates`, `ServicePacks`, `Tools`, `UpdateRollups`, `Updates` | Categories passed to `ansible.windows.win_updates` |
+| `allow_reboot` | `true` | Passed as `win_updates`' `reboot` option |
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Scan packages/services (`demo.patching.win_scan_packages`, `demo.patching.win_scan_services`), then install Windows Updates for `win_update_categories`. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.patching`](../../README.md) for the Windows patching demos in this repository.

--- a/collections/ansible_collections/demo/patching/roles/report_linux/README.md
+++ b/collections/ansible_collections/demo/patching/roles/report_linux/README.md
@@ -1,36 +1,45 @@
-build_report_linux
-========
+# demo.patching.report_linux
 
-Installs Apache and creates a report based on facts from Linux services and packages modules
+Build an HTML inventory report of a Linux host's installed packages and running services (from facts gathered by `demo.patching.patch_linux`), and copy it -- with shared CSS/logo assets -- to the report server's web root.
 
-Requirements
-------------
-
-Must run on Apache server
-
-Role Variables / Configuration
---------------
-
-N/A
-
-Dependencies
-------------
-
-N/A
-
-Example Playbook
-----------------
-
-The role can be used to create an html report on any number of Linux hosts using any number of Linux servers about their services and packages installed
-
-
+```yaml
+- name: Build report server
+  ansible.builtin.include_role:
+    name: "{{ item }}"
+  loop:
+    - demo.patching.report_server
+    - demo.patching.report_linux
+    - demo.patching.report_linux_patching
 ```
----
-- hosts: all
 
-  tasks:
-  - name: Run Linux Report
-    import_role:
-      name: shadowman.reports.build_report_linux
+Run after `demo.patching.report_server` (so the destination directory and web server exist) and after `demo.patching.patch_linux` on the target host (so package/service facts are populated).
 
-```
+Repo playbook: [`linux/patching.yml`](../../../../../../linux/patching.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: Linux host with an Apache document root already created (see `demo.patching.report_server`)
+- Package/service facts populated (`ansible.builtin.package_facts` / `service_facts`, run by `demo.patching.patch_linux`)
+
+## Role Variables
+
+Defaults live in `vars/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `file_path` | `/var/www/html/reports` | Destination directory for `linux.html`, CSS, and logo assets |
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Template `linux.html` from package/service facts, copy CSS and logo assets, and print the report URL. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.patching`](../../README.md) for the Linux patching report demos in this repository.

--- a/collections/ansible_collections/demo/patching/roles/report_linux_patching/README.md
+++ b/collections/ansible_collections/demo/patching/roles/report_linux_patching/README.md
@@ -1,36 +1,48 @@
-build_report_linux_patch
-========
+# demo.patching.report_linux_patching
 
-Installs Apache and creates a report based on facts from Linux patching
+Build an HTML patching report for a Linux host (`yum`/`dnf` upgrade results from `demo.patching.patch_linux`), and copy it -- with shared CSS/logo assets -- to the report server's web root.
 
-Requirements
-------------
-
-Must run on Apache server
-
-Role Variables / Configuration
---------------
-
-N/A
-
-Dependencies
-------------
-
-N/A
-
-Example Playbook
-----------------
-
-The role can be used to create an html report on any number of Linux hosts using any number of Linux servers about their patching results(yum and dnf)
-
-
+```yaml
+- name: Build report server
+  ansible.builtin.include_role:
+    name: "{{ item }}"
+  loop:
+    - demo.patching.report_server
+    - demo.patching.report_linux
+    - demo.patching.report_linux_patching
 ```
----
-- hosts: all
 
-  tasks:
-  - name: Run Windows Report
-    import_role:
-      name: shadowman.reports.build_report_linux_patch
+Run after `demo.patching.report_server` and after `demo.patching.patch_linux` on the target host so the `patch_linux_patchingresult_yum` / `patch_linux_patchingresult_dnf` facts used by the report template are populated. An optional (currently commented out) `community.general.mail` task can email the rendered report.
 
-```
+Repo playbook: [`linux/patching.yml`](../../../../../../linux/patching.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: Linux host with an Apache document root already created (see `demo.patching.report_server`)
+- Patching result facts registered by `demo.patching.patch_linux`
+
+## Role Variables
+
+Defaults live in `vars/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `file_path` | `/var/www/html/reports` | Destination directory for `linuxpatch.html`, CSS, and logo assets |
+| `email_from` | `tower@shadowman.dev` | `From` address for the optional (disabled) e-mail task |
+| `to_emails` | `alex@shadowman.dev,tower@shadowman.dev` | Comma-separated recipient list for the optional (disabled) e-mail task |
+| `to_emails_list` | `{{ to_emails.split(',') }}` | `to_emails` split into a list |
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Template `linuxpatch.html` from patching-result facts, copy CSS and logo assets, and print the report URL. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.patching`](../../README.md) for the Linux patching report demos in this repository.

--- a/collections/ansible_collections/demo/patching/roles/report_ocp_patching/README.md
+++ b/collections/ansible_collections/demo/patching/roles/report_ocp_patching/README.md
@@ -1,36 +1,39 @@
-build_report_linux_patch
-========
+# demo.patching.report_ocp_patching
 
-Installs Apache and creates a report based on facts from Linux patching
+Deploy a self-contained OpenShift-hosted patching report: an httpd Deployment backed by a ConfigMap (landing page, inventory report, patch report, CSS, and logo assets), a Service, and an edge-terminated Route -- for OpenShift Virtualization (CNV) patching demos where there is no dedicated Linux report server VM.
 
-Requirements
-------------
-
-Must run on Apache server
-
-Role Variables / Configuration
---------------
-
-N/A
-
-Dependencies
-------------
-
-N/A
-
-Example Playbook
-----------------
-
-The role can be used to create an html report on any number of Linux hosts using any number of Linux servers about their patching results(yum and dnf)
-
-
+```yaml
+- name: Publish landing page
+  ansible.builtin.include_role:
+    name: demo.patching.report_ocp_patching
 ```
----
-- hosts: all
 
-  tasks:
-  - name: Run Windows Report
-    import_role:
-      name: shadowman.reports.build_report_linux_patch
+Unlike the other reporting roles (which copy files onto an existing Apache/IIS server built by `demo.patching.report_server`), this role renders all report content into a single `ConfigMap` and runs it behind a Route -- no separate report server host is required.
 
-```
+Repo playbook: [`openshift/cnv/patch.yml`](../../../../../../openshift/cnv/patch.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: `localhost`, with OpenShift cluster access (run after `demo.patching.patch_linux` against the CNV-hosted VMs)
+- `redhat.openshift` collection (`k8s`)
+- An attached "OpenShift Credential" (type `OpenShift or Kubernetes API Bearer Token`) so `K8S_AUTH_HOST` / `K8S_AUTH_API_KEY` / `K8S_AUTH_VERIFY_SSL` are injected
+- Access to the `registry.redhat.io/rhel8/httpd-24` image from the cluster
+
+## Role Variables
+
+This role has no `defaults/main.yml` or non-empty `vars/main.yml`; the namespace (`patching-report`) and resource names are currently hardcoded in `tasks/main.yml` and `templates/resources.yaml.j2`.
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Create the `patching-report` namespace, apply the rendered `ConfigMap`/`Deployment`/`Service`/`Route` from `templates/resources.yaml.j2`, and print the report Route URL. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.patching`](../../README.md) for the OpenShift CNV patching demos in this repository.

--- a/collections/ansible_collections/demo/patching/roles/report_server/README.md
+++ b/collections/ansible_collections/demo/patching/roles/report_server/README.md
@@ -1,0 +1,56 @@
+# demo.patching.report_server
+
+Configure the shared report web server -- Apache on Linux, IIS on Windows -- that hosts the HTML reports built by the other `demo.patching` reporting roles, and publish the landing page that links to them.
+
+```yaml
+- name: Build report server
+  ansible.builtin.include_role:
+    name: "{{ item }}"
+  loop:
+    - demo.patching.report_server
+    - demo.patching.report_linux
+    - demo.patching.report_linux_patching
+
+- name: Publish landing page
+  ansible.builtin.include_role:
+    name: demo.patching.report_server
+    tasks_from: linux_landing_page
+```
+
+Run `main` first to install/start the web server and create the reports directory, then run the individual `build_report_*` / `report_*` roles to populate `*.html` files, then run the `linux_landing_page` or `windows_landing_page` entry point to (re)generate `index.html` linking to whatever reports currently exist.
+
+Repo playbooks: [`linux/patching.yml`](../../../../../../linux/patching.yml), [`windows/patching.yml`](../../../../../../windows/patching.yml), [`network/report.yml`](../../../../../../network/report.yml), [`network/backup.yml`](../../../../../../network/backup.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target (Linux): RHEL host with `become` and `dnf` (installs `httpd`)
+- Target (Windows): Windows host with the IIS `Web-Server` feature available
+- `ansible.windows` collection for the Windows entry points
+
+## Role Variables
+
+Defaults live in `vars/Linux.yml` (Linux) / `vars/Win32NT.yml` (Windows), selected automatically via `include_vars: "{{ ansible_system }}.yml"`.
+
+| Variable | Default (Linux) | Default (Windows) | Description |
+| --- | --- | --- | --- |
+| `doc_root` | `/var/www/html` | `C:\Inetpub\wwwroot` | Web server document root |
+| `reports_dir` | `reports` | `reports` | Subdirectory under `doc_root` where report HTML files live |
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Include Linux tasks (`apache.yml`) or Windows tasks (`iis.yml`) based on `ansible_system`. |
+| `apache.yml` | Install and start `httpd`, create the reports directory, and enable directory indexing via `.htaccess`. |
+| `iis.yml` | Install and start the `Web-Server` (IIS) feature, create the reports directory, and enable directory browsing. |
+| `linux_landing_page` | Find existing `*.html` reports and template `index.html` linking to them (Apache). |
+| `windows_landing_page` | Find existing `*.html` reports and template `index.html` linking to them (IIS). |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.patching`](../../README.md) for the patching report-server demos in this repository.

--- a/collections/ansible_collections/demo/patching/roles/report_windows/README.md
+++ b/collections/ansible_collections/demo/patching/roles/report_windows/README.md
@@ -1,36 +1,46 @@
-build_report_windows
-========
+# demo.patching.report_windows
 
-Installs Apache and creates a report based on facts from Windows services and packages modules
+Build an HTML inventory report of a Windows host's installed packages and running services (from facts gathered by `demo.patching.patch_windows`), and copy it -- with shared CSS/logo assets -- to the report server's web root.
 
-Requirements
-------------
-
-Must run on Apache server
-
-Role Variables / Configuration
---------------
-
-N/A
-
-Dependencies
-------------
-
-N/A
-
-Example Playbook
-----------------
-
-The role can be used to create an html report on any number of Linux hosts using any number of Windows servers about their services and packages installed
-
-
+```yaml
+- name: Install report server
+  ansible.builtin.include_role:
+    name: "{{ item }}"
+  loop:
+    - demo.patching.report_server
+    - demo.patching.report_windows
+    - demo.patching.report_windows_patching
 ```
----
-- hosts: all
 
-  tasks:
-  - name: Run Windows Report
-    import_role:
-      name: shadowman.reports.build_report_windows
+Run after `demo.patching.report_server` (so IIS and the destination directory exist) and after `demo.patching.patch_windows` on the target host (so package/service facts are populated).
 
-```
+Repo playbook: [`windows/patching.yml`](../../../../../../windows/patching.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: Windows host with the IIS document root already created (see `demo.patching.report_server`)
+- `ansible.windows` collection (`win_template`, `win_copy`)
+- Package/service facts populated by `demo.patching.patch_windows` (`demo.patching.win_scan_packages` / `win_scan_services`)
+
+## Role Variables
+
+Defaults live in `vars/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `file_path` | `C:\Inetpub\wwwroot\reports` | Destination directory for `windows.html`, CSS, and logo assets |
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Template `windows.html` from package/service facts and copy CSS and logo assets. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.patching`](../../README.md) for the Windows patching report demos in this repository.

--- a/collections/ansible_collections/demo/patching/roles/report_windows_patching/README.md
+++ b/collections/ansible_collections/demo/patching/roles/report_windows_patching/README.md
@@ -1,36 +1,49 @@
-build_report_windows_patch
-========
+# demo.patching.report_windows_patching
 
-Installs Apache and creates a report based on facts from Windows update job
+Build an HTML patching report for a Windows host (Windows Update results from `demo.patching.patch_windows`), and copy it -- with shared CSS/logo assets -- to the report server's web root.
 
-Requirements
-------------
-
-Must run on Apache server
-
-Role Variables / Configuration
---------------
-
-N/A
-
-Dependencies
-------------
-
-N/A
-
-Example Playbook
-----------------
-
-The role can be used to create an html patching report on any number of Linux hosts using any number of Windows servers
-
-
+```yaml
+- name: Install report server
+  ansible.builtin.include_role:
+    name: "{{ item }}"
+  loop:
+    - demo.patching.report_server
+    - demo.patching.report_windows
+    - demo.patching.report_windows_patching
 ```
----
-- hosts: all
 
-  tasks:
-  - name: Run Windows Patch Report
-    import_role:
-      name: shadowman.reports.build_report_windows_patch
+Run after `demo.patching.report_server` and after `demo.patching.patch_windows` on the target host. **Note:** `templates/report.j2` reads `hostvars[windows_host].patchingresult`, but `demo.patching.patch_windows` registers the result as `patch_windows_patchingresult` -- as shipped, the template's `is defined` guard means the updates table silently renders empty rather than erroring.
 
-```
+Repo playbook: [`windows/patching.yml`](../../../../../../windows/patching.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: Windows host with the IIS document root already created (see `demo.patching.report_server`)
+- `ansible.windows` collection (`win_template`, `win_copy`)
+- Patching result facts registered by `demo.patching.patch_windows`
+
+## Role Variables
+
+Defaults live in `vars/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `file_path` | `C:\Inetpub\wwwroot\reports` | Destination directory for `windowspatch.html`, CSS, and logo assets |
+| `email_from` | `tower@shadowman.dev` | Reserved for future e-mail notification support (unused by current tasks) |
+| `to_emails` | `alex@shadowman.dev,tower@shadowman.dev` | Reserved for future e-mail notification support (unused by current tasks) |
+| `to_emails_list` | `{{ to_emails.split(',') }}` | `to_emails` split into a list |
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Template `windowspatch.html` from Windows Update result facts and copy CSS and logo assets. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.patching`](../../README.md) for the Windows patching report demos in this repository.

--- a/collections/ansible_collections/demo/satellite/README.md
+++ b/collections/ansible_collections/demo/satellite/README.md
@@ -10,5 +10,5 @@ This collection is not published to Ansible Galaxy or Automation Hub; it exists 
 
 | Role | Description |
 |------|-------------|
-| [register_host](roles/register_host/) | Register a RHEL host with Red Hat Satellite via an activation key, enable repos, and install remote execution tooling. |
+| [register_host](roles/register_host/README.md) | Register a RHEL host with Red Hat Satellite via an activation key, enable repos, and install remote execution tooling. |
 | [scap_client](roles/scap_client/README.md) | Configure a client to run OpenSCAP compliance policies using configuration obtained from Satellite/Foreman. |

--- a/collections/ansible_collections/demo/satellite/README.md
+++ b/collections/ansible_collections/demo/satellite/README.md
@@ -1,0 +1,14 @@
+# demo.satellite
+
+Local collection containing roles used by the [Satellite demos](../../../../satellite/README.md) in ansible-product-demos.
+
+This collection is not published to Ansible Galaxy or Automation Hub; it exists solely to organize roles used by playbooks in this repository under the `demo.satellite` namespace.
+
+## Contents
+
+### Roles
+
+| Role | Description |
+|------|-------------|
+| [register_host](roles/register_host/) | Register a RHEL host with Red Hat Satellite via an activation key, enable repos, and install remote execution tooling. |
+| [scap_client](roles/scap_client/README.md) | Configure a client to run OpenSCAP compliance policies using configuration obtained from Satellite/Foreman. |

--- a/collections/ansible_collections/demo/satellite/galaxy.yml
+++ b/collections/ansible_collections/demo/satellite/galaxy.yml
@@ -1,0 +1,17 @@
+---
+namespace: demo
+name: satellite
+version: 1.0.0+08062601
+readme: README.md
+authors:
+  - Ansible Product Demos (https://github.com/ansible/product-demos)
+description: Roles supporting Red Hat Satellite automation demos in ansible-product-demos.
+license:
+  - GPL-3.0-or-later
+tags:
+  - apd
+  - satellite
+  - linux
+repository: https://github.com/ansible/product-demos
+issues: https://github.com/ansible/product-demos/issues
+...

--- a/collections/ansible_collections/demo/satellite/meta/runtime.yml
+++ b/collections/ansible_collections/demo/satellite/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: ">=2.16.0"

--- a/collections/ansible_collections/demo/satellite/roles/register_host/README.md
+++ b/collections/ansible_collections/demo/satellite/roles/register_host/README.md
@@ -12,14 +12,14 @@ Register a RHEL host with Red Hat Satellite using an activation key, replacing a
     - demo.satellite.register_host
 ```
 
-The activation key defaults to `RHEL<major version>_<env>` (for example `RHEL9_dev`), so the target host's Satellite organization must have a matching activation key. RHSM repos are chosen per OS release from `vars/RedHat7.yml` / `vars/RedHat8.yml`; RHEL 9 hosts fall back to whatever activation key content view defines by default (no OS-specific repo file is shipped for RHEL 9).
+The activation key defaults to `RHEL<major version>_<env>` (for example `RHEL8_dev`), so the target host's Satellite organization must have a matching activation key. RHSM repos are chosen per OS release from `vars/RedHat7.yml` / `vars/RedHat8.yml`. RHEL 9 is not supported today: `tasks/main.yml` asserts major version is `7` or `8`, and no `vars/RedHat9.yml` is shipped.
 
 Repo playbook: [`satellite/server_register.yml`](../../../../../../satellite/server_register.yml).
 
 ## Requirements
 
 - ansible-core >= 2.16.0
-- Target: RHEL 7/8/9 host reachable over SSH with `become`
+- Target: RHEL 7 or 8 host reachable over SSH with `become` (RHEL 9 is asserted out)
 - `community.general` collection (`redhat_subscription`, `rhsm_repository`)
 - `ansible.posix` collection (`authorized_key`)
 - Network access from the target host to the Satellite server (`satellite_url`) and a valid activation key for the host's org

--- a/collections/ansible_collections/demo/satellite/roles/register_host/README.md
+++ b/collections/ansible_collections/demo/satellite/roles/register_host/README.md
@@ -1,0 +1,53 @@
+# demo.satellite.register_host
+
+Register a RHEL host with Red Hat Satellite using an activation key, replacing any RHUI repos, enabling the Satellite-managed RHSM repos for the host's OS release, and enabling Satellite remote execution (SSH key from the Satellite/Capsule).
+
+```yaml
+- name: Register host to Satellite
+  hosts: "{{ _hosts | default(omit) }}"
+  become: true
+  vars:
+    satellite_url: "{{ lookup('ansible.builtin.env', 'SATELLITE_SERVER') }}"
+  roles:
+    - demo.satellite.register_host
+```
+
+The activation key defaults to `RHEL<major version>_<env>` (for example `RHEL9_dev`), so the target host's Satellite organization must have a matching activation key. RHSM repos are chosen per OS release from `vars/RedHat7.yml` / `vars/RedHat8.yml`; RHEL 9 hosts fall back to whatever activation key content view defines by default (no OS-specific repo file is shipped for RHEL 9).
+
+Repo playbook: [`satellite/server_register.yml`](../../../../../../satellite/server_register.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: RHEL 7/8/9 host reachable over SSH with `become`
+- `community.general` collection (`redhat_subscription`, `rhsm_repository`)
+- `ansible.posix` collection (`authorized_key`)
+- Network access from the target host to the Satellite server (`satellite_url`) and a valid activation key for the host's org
+
+## Role Variables
+
+Defaults live in `defaults/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `instance_name` | `{{ inventory_hostname | regex_replace('_', '-') }}` | Consumer name registered in Satellite (underscores replaced with hyphens) |
+| `activation_key` | `RHEL<major_version>_<env>` | Activation key used for `redhat_subscription`; requires `env` to be set by the caller |
+| `rex_user` | `root` | User account that receives the Satellite remote execution SSH public key |
+| `force_register` | `true` | Passed to `community.general.redhat_subscription` as `force_register` |
+| `satellite_url` | required (caller-supplied) | Base URL of the Satellite server; used for the Katello CA RPM, remote execution pubkey, and (via `capsule_server`, in `scap_client`) other Satellite APIs |
+| `org_id` | `Default_Organization` | Passed to `redhat_subscription`; override for non-default orgs |
+| `rhsm_enabled_repos` | OS-specific (`vars/RedHat7.yml`, `vars/RedHat8.yml`) | List of repos enabled via `rhsm_repository`; selected by `include_vars` on `ansible_distribution + ansible_distribution_major_version` |
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Verify RHEL 7/8, set hostname, remove RHUI client packages/repos, install the Katello CA RPM, register via activation key, enable OS-specific RHSM repos, install `katello-host-tools`, and authorize the Satellite remote execution SSH key. |
+
+## License
+
+GPL-3.0-or-later
+
+## Authors and Acknowledgments
+
+- Ansible Product Demos -- maintained as part of [`demo.satellite`](../../README.md) for the Satellite registration demos in this repository.

--- a/collections/ansible_collections/demo/satellite/roles/scap_client/README.md
+++ b/collections/ansible_collections/demo/satellite/roles/scap_client/README.md
@@ -1,45 +1,59 @@
-# Openscap client configuration Role
+# demo.satellite.scap_client
 
-## About
+Configure a host to run OpenSCAP compliance scans reported back to Red Hat Satellite/Foreman: install the OpenSCAP scanner and `foreman_scap_client`, look up the matching compliance policy (and any tailoring file) from the Satellite API, and template `/etc/foreman_scap_client/config.yaml`.
 
-Role created to configure a client to execute openscap policies based on the information obtained from a Red Hat Satellite/Foreman Host.
+Adapted from the [foreman_scap_client Puppet module](https://github.com/theforeman/puppet-foreman_scap_client). The role must run with root privileges (directly as root or via `become`) because it modifies system configuration.
 
-Steps and configuration changes obtained from the [foreman_scap_client puppet module](https://github.com/theforeman/puppet-foreman_scap_client)
-
-The role has to be executed with root permission, using the root user or via sudo because it will modify system parameters.
-
-## Ansible Requirements
-
-RPM Repositories have to be enabled and containing required packages.
-
-## Configuration parameters
-
-### Required vars to be overwritten
-
-- `satellite_server`: Used to obtain policy parameters
-- `satellite_username`: Used to obtain policy parameters
-- `satellite_password`: Used to obtain policy parameters
-- `capsule_server`: Used to configure openscap client config.yaml file
-- `capsule_port`: Used to configure openscap client config.yaml file
-- `policy_name`: Name of the SCAP Policy to be configured
-
-## Example playbook
-
-```yml
----
-- name: openscap client
-  hosts: <<host list>>
-  remote_user: <<user>>
-  gather_facts: true
-  become: yes
-  become_user: root
-  become_method: sudo
+```yaml
+- name: Run openSCAP scan
+  hosts: "{{ _hosts | default(omit) }}"
+  become: true
   vars:
-    satellite_server: satellite.example.com
-    satellite_username`: admin
-    satellite_password`: verycomplexpassword
-    capsule_server`: capsule.example.com
-    policy_name`: 'rhel7-pci'
+    policy_name: all
   roles:
-        - ansible-ipaRegister
+    - demo.satellite.scap_client
 ```
+
+The scan itself is not triggered by this role -- after the config is templated, the caller runs `foreman_scap_client <policy id>` (see the repo playbook, which loops over the resolved `policy` list).
+
+Repo playbook: [`satellite/server_openscap.yml`](../../../../../../satellite/server_openscap.yml).
+
+## Requirements
+
+- ansible-core >= 2.16.0
+- Target: RHEL host with `dnf` and `become` (root); RPM repos providing `openscap-scanner` and `rubygem-foreman_scap_client` must be enabled (for example via `demo.satellite.register_host`)
+- Network access from the target host to the Satellite server (`foreman_server_url`) to query the Compliance API
+- A Satellite user (`foreman_username` / `foreman_password`) with permission to read Compliance policies, SCAP contents, and tailoring files
+- The host must already have a Compliance policy assigned in Satellite that matches `policy_name`
+
+## Role Variables
+
+Defaults live in `defaults/main.yaml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `foreman_server_url` | `env:SATELLITE_SERVER` | Base URL of the Satellite/Foreman server used for the Compliance API |
+| `foreman_username` | `env:SATELLITE_USERNAME` | Satellite API username (basic auth) |
+| `foreman_password` | `env:SATELLITE_PASSWORD` | Satellite API password (basic auth); logged calls that use it are suppressed via `no_log` |
+| `foreman_validate_certs` | `env:FOREMAN_VALIDATE_CERTS` (default `true`) | Whether to validate TLS certs; API lookups in `tasks/main.yaml` currently always pass `validate_certs: false` |
+| `capsule_server` | `{{ foreman_server_url }}` | Proxy/Capsule hostname written into `config.yaml` as `:server:` |
+| `capsule_port` | `'9090'` | Port written into `config.yaml` as `:port:` |
+| `policy_name` | `'all'` | Compliance policy name to match (or `all` for every policy assigned to the host) |
+| `policy_scan` | `{{ policy_name }}` | Policy name(s) the caller's scan loop should execute against |
+| `crontab_hour` / `crontab_minute` / `crontab_weekdays` | `2` / `0` / `0` | Reserved for a scheduled-scan cron job; the cron task in `tasks/main.yaml` is currently commented out |
+| `foreman_operations_scap_client_secure_logging` | `true` | When `true`, suppresses logging (`no_log`) on the Satellite API calls that carry credentials |
+
+## Entry points
+
+| Entry point | Description |
+| --- | --- |
+| `main` (default) | Install OpenSCAP packages, resolve the matching policy/SCAP content/tailoring file from the Satellite Compliance API, and template `/etc/foreman_scap_client/config.yaml`. |
+
+## License
+
+MIT (see [`LICENSE`](LICENSE)) -- this role predates the collection's GPL-3.0-or-later default and keeps its original license.
+
+## Authors and Acknowledgments
+
+- **morenod** -- original author (2018), see [`LICENSE`](LICENSE) and [`Changelog.md`](Changelog.md).
+- Adapted from the [`foreman_scap_client` Puppet module](https://github.com/theforeman/puppet-foreman_scap_client).


### PR DESCRIPTION
## Summary

Adds Ansible collection metadata and standardizes role-level documentation across the four local collections in the `demo` namespace (`cloud`, `compliance`, `patching`, `satellite`), and refreshes stale Ansible version requirements in the `openshift` collection's role docs.

- Adds `galaxy.yml`, `meta/runtime.yml` (`requires_ansible: ">=2.16.0"`), and a top-level `README.md` for each of the `demo.cloud`, `demo.compliance`, `demo.patching`, and `demo.satellite` collections, documenting each collection's purpose and linking to its roles (and modules, for `demo.patching`).
- Adds new/updated `README.md` files for every role in these four collections (e.g. `aws`, `reports`, `retrieve_info`, `retrieve_aws_instances_info`, the STIG compliance roles, `patch_linux`, `patch_windows`, `report_server`, `register_host`, etc.), describing purpose, requirements, and usage.
- Updates the `openshift` collection's `cluster_config`, `eda_controller`, `snapshot`, and `vault` role READMEs to replace outdated `Ansible 2.9+`/`2.14+` requirements with the consistent `ansible-core >= 2.16.0` used elsewhere.

## Test plan

- [ ] Spot-check rendered READMEs on GitHub for formatting/links