### PR TITLE
fix: Mermaid edge label rendering (black bars + clipped text)

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -86,6 +86,13 @@
         el.style.setProperty('color', '#ffffff', 'important');
         el.style.setProperty('margin', '0');
       });
+      document.querySelectorAll('[id^="mermaid-"] .edgeLabel rect').forEach(function(el) {
+        el.setAttribute('fill', 'transparent');
+        el.setAttribute('opacity', '0');
+      });
+      document.querySelectorAll('[id^="mermaid-"] .edgeLabel foreignObject').forEach(function(el) {
+        el.style.setProperty('overflow', 'visible');
+      });
       document.querySelectorAll('[id^="mermaid-"] .edgeLabel p').forEach(function(el) {
         el.style.setProperty('background-color', 'rgba(232, 232, 232, 0.8)', 'important');
         el.style.setProperty('color', '#000000', 'important');

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -1153,18 +1153,8 @@ html:not([data-theme="dark"]) .demo-card:hover {
   font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 }
 
-.workflow-diagram .mermaid .edgeLabel rect {
-  fill: var(--bg-body) !important;
-  opacity: 1 !important;
-}
-
-.workflow-diagram .mermaid .edgeLabel p,
-.workflow-diagram .mermaid .edgeLabel span {
-  color: var(--text-primary) !important;
-  background: var(--bg-body) !important;
-  border-radius: 4px;
-  padding: 1px 4px;
-}
+/* Edge label colors are applied post-render by JS in default.html.
+   Do not add fill/color/background rules here — they fight inline !important. */
 
 .btn {
   display: inline-flex;


### PR DESCRIPTION
## Summary

Fixes two visual bugs on workflow diagram edge labels (success / failure / always):

1. **Black bars above and below labels** — `site.css` set `.edgeLabel rect { fill: var(--bg-body) }`, painting a dark SVG rect behind the lighter `<p>` pill. The rect is taller than the `<p>`, so the dark fill peeked out at top and bottom. Fix: remove the CSS rules and set the SVG rect to `transparent` / `opacity: 0` in the post-render JS (which is the single source of truth for label styling).

2. **Clipped label text** — Mermaid sizes `foreignObject` to exactly fit the raw text width, but the `padding: 1px 4px` on the `<p>` makes it ~8px wider. The default `overflow: hidden` on `foreignObject` was truncating "success" → "succes". Fix: set `overflow: visible` on edge label `foreignObject` elements post-render.

### Before / After

_Screenshots in the first comment below._

## Changes

- **`docs/assets/css/site.css`** — Remove `.edgeLabel rect` and `.edgeLabel p` CSS rules that conflicted with the JS post-render fix
- **`docs/_layouts/default.html`** — Add JS to zero out the SVG rect fill and set `overflow: visible` on edge label `foreignObject` elements

## Test plan

- [ ] Open any workflow demo page (e.g. Patch Cloud Stack, Deploy Cloud Stack) in dark mode
- [ ] Verify edge labels ("success", "failure", "always") show black text on a light gray pill, with no dark bars and no text clipping
- [ ] Toggle to light mode and verify labels remain readable

Made with [Cursor](https://cursor.com)