### PR TITLE
ci: fix fork PR pre-commit by switching to pull_request

### DIFF
--- a/.cursor/rules/pre-commit-workflow.mdc
+++ b/.cursor/rules/pre-commit-workflow.mdc
@@ -11,4 +11,4 @@ When changing playbooks, roles, AAP setup YAML, or collections in this repo, run
 python3 -m pre_commit run --config .pre-commit-gh.yml --files $(git diff --name-only -- '*.yml' '*.yaml' '*.j2' | tr '\n' ' ')
 ```
 
-For fork PRs, upstream CI uses `pull_request_target` and checks out **base** `main` until `.github/workflows/pre-commit.yml` on main is updated to checkout `github.event.pull_request.head.sha`. Lint fixes in the PR branch apply after merge.
+CI uses `.github/workflows/pre-commit.yml` with the `pull_request` event (not `pull_request_target`) so fork PRs are linted without privileged checkout. See `.github/workflows/README.md` for the short why.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,6 +7,44 @@ We want to make attempts to run our integration tests in the same manner wether 
 
 These images are built given the structure defined in their respective EE [definitions][../execution_environments]. Because they differ (mainly due to their python versions), each gets some special handling.
 
+## pre-commit workflow: `pull_request` vs `pull_request_target`
+
+The `pre-commit.yml` job only lints code. It does **not** need repo secrets.
+
+### The simple mental model
+
+Think of two kinds of CI runs:
+
+| Trigger | Who's keys does the job hold? | Safe to run the PR's scripts? |
+|---|---|---|
+| `pull_request` | Visitor badge (no secrets) | Yes — lint the PR code |
+| `pull_request_target` | Building keys (base repo token + secrets) | Risky — "pwn request" |
+
+We **do** want to run lint against pull request code. That is the whole point of the check.
+
+What we **do not** want is: give a fork PR the building keys, then check out and execute that fork's scripts.
+
+### What was broken
+
+1. Fork PRs (e.g. contributor `someone/product-demos` → `ansible/product-demos`) triggered `pull_request_target`.
+2. The workflow checked out the fork and ran `./.github/workflows/run-pc.sh` from that tree while holding base-repo trust.
+3. In mid-2026, `actions/checkout` started refusing that pattern by default (`allow-unsafe-pr-checkout` required), so `pre-commit-25` failed at **checkout** — before ansible-lint ever ran.
+4. Local ansible-lint could pass while GitHub showed red. That red was a CI security gate, not a code lint failure.
+
+Because `pull_request_target` always uses the workflow file from the **base** branch (`main`), fixing the YAML only inside a fork PR does not help until the fix lands on `main`.
+
+### The fix
+
+Use `pull_request` (plus `push`) and a normal checkout:
+
+- CI still checks out and lints the PR code.
+- The job runs without secrets / privileged base-repo access.
+- Fork PRs no longer hit the checkout refusal.
+
+Trade-offs for this lint-only job are small: no secrets access (we do not need any), and first-time fork contributors may need a maintainer to approve the workflow run once (GitHub org setting).
+
+Do **not** reintroduce `pull_request_target` here unless this job truly needs secrets **and** untrusted PR code is never executed with those privileges.
+
 ## Troubleshooting GitHub Actions
 
 ### Interactive

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,8 +1,8 @@
 ---
 name: pre-commit
 on:
- - push
- - pull_request_target
+  - push
+  - pull_request
 
 jobs:
   pre-commit-25:
@@ -12,12 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      if: github.event_name == 'push'
-    - uses: actions/checkout@v4
-      if: github.event_name == 'pull_request_target'
-      with:
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        ref: ${{ github.event.pull_request.head.sha }}
     - run: ./.github/workflows/run-pc.sh
       shell: bash
-


### PR DESCRIPTION
## Summary
- Switch `pre-commit.yml` from `pull_request_target` to `pull_request` with a normal checkout
- Document the simple mental model in `.github/workflows/README.md` (visitor badge vs building keys)
- Update the Cursor pre-commit rule so it no longer describes the outdated fork checkout failure mode

## Why this was red on fork PRs
`pre-commit-25` was failing at **checkout**, not ansible-lint.

1. Fork PRs ran under `pull_request_target` (base-repo privileges / secrets).
2. The job then checked out the fork and ran `run-pc.sh` from that tree.
3. Mid-2026 `actions/checkout` refuses that pattern by default (pwn-request protection).
4. Local lint could pass while GitHub showed red — because CI never reached lint.

We **do** want to lint PR code. We **do not** want to give fork PRs the building keys while running their scripts. This lint job needs no secrets, so `pull_request` is the right trigger.

Because `pull_request_target` always uses the workflow from `main`, the fix has to land on `main` before future fork PRs benefit.

## Test plan
- [ ] Confirm this PR’s `pre-commit` check runs under `pull_request` and passes
- [ ] After merge, open or re-run a fork PR and confirm checkout no longer refuses
- [ ] Skim `.github/workflows/README.md` section for clarity for other maintainers


Made with [Cursor](https://cursor.com)