### PR TITLE
Fix PanOS deployment failure

### DIFF
--- a/network/panos/deploy.yml
+++ b/network/panos/deploy.yml
@@ -263,7 +263,7 @@
               "admin@PA-VM>":
                 - "configure"
                 - "exit"
-              "admin@PA-VM  #":
+              "admin@PA-VM#":
                 - "set mgt-config users admin password"
                 - "commit"
                 - "exit"


### PR DESCRIPTION
During PanOS deployment, the task that sets the admin password consistently fails. I have found that the real prompt doesn't match what's in the task as there are extra spaces throwing it off. I have just removed the spaces. Works for me.