### PR TITLE
docs: address ROSA PR #332 review feedback

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -2,7 +2,7 @@
 
 ## About These Demos
 
-This category covers automated infrastructure provisioning and lifecycle management through Ansible Automation Platform. Unlike the [Cloud](../cloud/README.md) demos which manage individual AWS resources (VMs, VPCs, keypairs) or the [OpenShift](../openshift/README.md) demos which assume a cluster already exists, these demos provision and destroy managed platforms end-to-end.
+This category covers automated provisioning and lifecycle management of IT infrastructure through Ansible Automation Platform. This includes any infrastructure that APD may provision for demo purposes — managed platforms, lab environments, shared services, and supporting resources.
 
 ### ROSA (Red Hat OpenShift Service on AWS)
 

--- a/infrastructure/docs/rosa-lifecycle.md
+++ b/infrastructure/docs/rosa-lifecycle.md
@@ -8,6 +8,7 @@ Automated Red Hat OpenShift Service on AWS (ROSA) cluster lifecycle management: 
 - ROSA Token credential (obtain offline token from https://console.redhat.com/openshift/token/rosa)
 - ROSA Lifecycle EE available (`quay.io/acme_corp/rosa-ee:latest`)
 - Sufficient AWS service quotas (EC2, VPC, ELB, EIP) in target region
+  - **EIP**: ROSA requires at least 1 free Elastic IP quota slot (default account quota is 5). If you already have 5 EIPs allocated, [request a quota increase](https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html) for the **EC2 → Elastic IP addresses** service quota (quota code `L-0263D0A3`) or release unused EIPs before creating a cluster
 
 ## Configure credentials
 


### PR DESCRIPTION
Addresses review comments from @jce-redhat on #332:

## Code changes

**EIP quota documentation** ([comment](https://github.com/ansible/product-demos/pull/332)):
- Added specific EIP guidance to prerequisites: default quota is 5, ROSA needs at least 1 free slot, with a link to the [AWS quota increase docs](https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html) and the quota code (`L-0263D0A3`)

**Infrastructure README wording** ([comment](https://github.com/ansible/product-demos/pull/332)):
- Broadened description from "managed platforms" to "any IT infrastructure that APD may provision for demo purposes"

## Issues filed

**AWS CLI → amazon.aws modules** ([comment](https://github.com/ansible/product-demos/pull/332)):
- Filed #333 to track migrating `aws` CLI calls to native `amazon.aws` collection modules

**Containerlab → infrastructure category** ([comment](https://github.com/ansible/product-demos/pull/332)):
- Filed #334 to track moving containerlab deploy/destroy workflows into the infrastructure category

## No change needed

- **EE question**: Self-resolved ("nvm i see this uses a different EE")
- **`changed_when: false` style**: Using `changed_when: false` on read-only `ansible.builtin.command` calls is standard practice and consistent with the rest of the repo
- **Separate PRs**: Noted for future contributions


Made with [Cursor](https://cursor.com)