### PR TITLE
add OPA server deployment demo

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -44,6 +44,7 @@ mock_modules:
   - amazon.aws.s3_object_info
   - ansible.controller.credential
   - ansible.controller.host
+  - ansible.controller.settings
   - ansible.posix.at
   - ansible.posix.mount
   - ansible.posix.authorized_key
@@ -100,6 +101,7 @@ mock_modules:
   - paloaltonetworks.panos.panos_security_rule
   - paloaltonetworks.panos.panos_zone
   - redhat.openshift.k8s
+  - redhat.openshift.openshift_route
   - redhat.openshift_virtualization.kubevirt_vm_info
   - redhat.satellite.content_view_version
   - redhat.satellite.scap_tailoring_file

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -86,6 +86,7 @@ mock_modules:
   - containers.podman.podman_container
   - containers.podman.podman_image
   - kubernetes.core.k8s
+  - kubernetes.core.k8s_cluster_info
   - kubernetes.core.k8s_info
   - microsoft.ad.domain
   - microsoft.ad.group

--- a/docs/_data/demos.yml
+++ b/docs/_data/demos.yml
@@ -1573,3 +1573,64 @@
   stats:
     playbooks: 1
   github_path: infrastructure/rosa/destroy.yml
+
+- slug: opa-policy-as-code
+  readme_path: infrastructure/docs/opa-policy-as-code.md
+  title: "Infrastructure | OPA — Policy as Code"
+  subtitle: "Enforce governance policies on AAP job execution with Open Policy Agent"
+  category: infrastructure
+  status: active
+  featured: false
+  tags:
+    - Playbook
+    - Survey
+    - OpenShift
+    - OPA
+    - Policy
+    - Governance
+  thumbnail:
+    gradient: "linear-gradient(135deg, #566b78 0%, #2c3e50 100%)"
+    icon: "🛡️"
+  blurb: "Deploy Open Policy Agent on OpenShift and configure AAP Policy as Code to enforce maintenance windows, superuser restrictions, and custom Rego policies."
+  stats:
+    playbooks: 2
+  url: /demos/opa-policy-as-code/
+  github_path: infrastructure/setup.yml
+
+- slug: opa-deploy
+  readme_path: infrastructure/docs/opa-policy-as-code.md
+  url: /demos/opa-deploy/
+  title: "Infrastructure | OPA — Deploy Open Policy Agent"
+  category: infrastructure
+  status: active
+  tags:
+    - Playbook
+    - Survey
+    - OpenShift
+    - OPA
+  thumbnail:
+    gradient: "linear-gradient(135deg, #566b78 0%, #2c3e50 100%)"
+    icon: "🛡️"
+  blurb: "Deploy OPA on OpenShift with bundled Rego policies and configure AAP's Policy as Code settings."
+  stats:
+    playbooks: 1
+  github_path: infrastructure/opa/deploy-opa.yml
+
+- slug: opa-add-policy
+  readme_path: infrastructure/docs/opa-policy-as-code.md
+  url: /demos/opa-add-policy/
+  title: "Infrastructure | OPA — Add Policy"
+  category: infrastructure
+  status: active
+  tags:
+    - Playbook
+    - Survey
+    - OpenShift
+    - OPA
+  thumbnail:
+    gradient: "linear-gradient(135deg, #566b78 0%, #2c3e50 100%)"
+    icon: "🛡️"
+  blurb: "Upload a custom Rego policy to a running OPA server via the REST API at runtime."
+  stats:
+    playbooks: 1
+  github_path: infrastructure/opa/add-policy.yml

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -36,8 +36,8 @@ This category covers automated provisioning and lifecycle management of IT infra
 
 | Job Template | Description |
 |--------------|-------------|
-| **OPA ǀ Deploy Open Policy Agent** | Deploys OPA on OpenShift, loads bundled Rego policies into a ConfigMap, and configures AAP's Policy as Code settings |
-| **OPA ǀ Add Policy** | Uploads a Rego policy to OPA via the REST API (in-memory only, does not persist across pod restarts) |
+| **Infrastructure | OPA - Deploy Open Policy Agent on OpenShift** | Deploys a demo (non-production) OPA on OpenShift, loads bundled Rego policies into a ConfigMap, and configures AAP's Policy as Code settings |
+| **Infrastructure | OPA - Add Policy** | Uploads a Rego policy to OPA via the REST API (in-memory only, does not persist across pod restarts) |
 
 ## Post Setup
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -30,6 +30,15 @@ This category covers automated provisioning and lifecycle management of IT infra
 |--------------|-------------|
 | **Vault** | Install or remove HashiCorp Vault on an OpenShift cluster via the HashiCorp Helm chart (dev mode). Install seeds the KV v2 secrets engine and userpass auth with sample credentials. |
 
+### OPA (Open Policy Agent)
+
+#### Jobs
+
+| Job Template | Description |
+|--------------|-------------|
+| **OPA ǀ Deploy Open Policy Agent** | Deploys OPA on OpenShift, loads bundled Rego policies into a ConfigMap, and configures AAP's Policy as Code settings |
+| **OPA ǀ Add Policy** | Uploads a Rego policy to OPA via the REST API (in-memory only, does not persist across pod restarts) |
+
 ## Post Setup
 
 After running `APD | Single demo setup` with `demo: infrastructure`:

--- a/infrastructure/docs/opa-policy-as-code.md
+++ b/infrastructure/docs/opa-policy-as-code.md
@@ -66,6 +66,9 @@ policy_as_code_vars:
   allow_superuser: true
 ```
 
+> [!NOTE]
+> The demo policies use the `policy_as_code_vars` extra_vars for convenience, but these can be overridden when a job template is configured to prompt for extra_vars on launch.  In a production scenario, either the prompt on launch for extra_vars should be disabled on a job template that passes variables in to OPA for processing, or static policies that cannot be modified through AAP should be used.
+
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `maintenance_window_start` | Start of the allowed execution window (HH:MM, 24-hour) | Not set (no restriction) |
@@ -89,6 +92,7 @@ policy_as_code_vars:
 6. Add `policy_as_code_vars` to the organization or job template's extra_vars with a maintenance window that excludes the current time — run the job to show it is denied with a message indicating the allowed window
 7. Adjust the maintenance window to include the current time and re-run to show it is allowed
 8. Optionally use **Infrastructure | OPA - Add Policy** to upload a custom policy via the REST API, demonstrating runtime policy updates without redeployment
+  - If you customized the namespace in Step 1, be sure to use the same namespace value when adding a policy
 
 ## Talking points
 

--- a/infrastructure/docs/opa-policy-as-code.md
+++ b/infrastructure/docs/opa-policy-as-code.md
@@ -1,6 +1,6 @@
 # OPA — Policy as Code
 
-Demonstrate AAP's Policy as Code feature using Open Policy Agent (OPA) deployed on OpenShift. The demo deploys an OPA server, loads Rego policies, and configures AAP to evaluate policies before allowing jobs to run.
+Demonstrate AAP's Policy as Code feature using Open Policy Agent (OPA) deployed on OpenShift. The demo deploys an OPA server, loads Rego policies, and configures AAP to evaluate policies before allowing jobs to run.  The OPA server is not configured for production use as it does not require authentication.
 
 ## Prerequisites
 
@@ -81,7 +81,7 @@ policy_as_code_vars:
 
 ## Presenter walkthrough
 
-1. Run **Infrastructure | OPA - Deploy Open Policy Agent** — accept the defaults or customize the namespace and image. After the job completes, confirm the OPA server URL in the output
+1. Run **Infrastructure | OPA - Deploy Open Policy Agent on OpenShift** — accept the defaults or customize the namespace and image. After the job completes, confirm the OPA server URL in the output
 2. Apply the `apd/deny_all` policy to the demo organization in AAP (Access → Organizations → edit → Policy enforcement → set OPA query path to `apd/deny_all`)
 3. Run any job template in that organization — show that it is denied with the message "'Deny all' policy is in effect"
 4. Change the organization's policy to `apd/common_policies` — run a job as a regular user to show it is now allowed (no `policy_as_code_vars` configured, so the policy allows all jobs by default)

--- a/infrastructure/docs/opa-policy-as-code.md
+++ b/infrastructure/docs/opa-policy-as-code.md
@@ -1,0 +1,106 @@
+# OPA — Policy as Code
+
+Demonstrate AAP's Policy as Code feature using Open Policy Agent (OPA) deployed on OpenShift. The demo deploys an OPA server, loads Rego policies, and configures AAP to evaluate policies before allowing jobs to run.
+
+## Prerequisites
+
+- OpenShift cluster with privileges to create projects, deployments, services, and routes
+- OpenShift Credential configured in AAP (bearer token for cluster authentication)
+- AAP Credential configured in AAP (for updating Policy as Code settings)
+
+## Configure credentials
+
+| Credential | Type | Where to get it |
+|------------|------|-----------------|
+| OpenShift Credential | OpenShift or Kubernetes API Bearer Token | OpenShift console — Service Account or user token |
+| AAP Credential | Red Hat Ansible Automation Platform | AAP instance — admin credentials |
+
+## Survey prompts
+
+### Deploy Open Policy Agent
+
+| Prompt | Variable | Type | Required |
+|--------|----------|------|----------|
+| OPA namespace | `opa_namespace` | text | Yes |
+| OPA container image | `opa_image` | text | Yes |
+
+### Add Policy
+
+| Prompt | Variable | Type | Required |
+|--------|----------|------|----------|
+| OPA namespace | `opa_namespace` | text | Yes |
+| Policy name | `opa_policy_name` | text | Yes |
+| Rego policy text | `opa_policy_text` | textarea | Yes |
+
+## Job templates
+
+| Template | Playbook | Description |
+|----------|----------|-------------|
+| OPA ǀ Deploy Open Policy Agent | [`infrastructure/opa/deploy-opa.yml`](../opa/deploy-opa.yml) | Deploys OPA on OpenShift, loads bundled Rego policies, and configures AAP's Policy as Code settings |
+| OPA ǀ Add Policy | [`infrastructure/opa/add-policy.yml`](../opa/add-policy.yml) | Uploads a Rego policy to OPA via the REST API (in-memory only, does not persist across pod restarts) |
+
+## Included policies
+
+### deny_all
+
+A simple policy that denies all job execution. Useful for demonstrating that Policy as Code enforcement is working, or for "maintenance mode" scenarios.
+
+**Query path**: `apd/deny_all`
+
+### common_policies
+
+A combined policy with two checks:
+
+- **Maintenance window** — Restricts job execution to a configurable time window. Supports HH:MM format, wrapping windows (e.g. 22:00–06:00), and timezone configuration.
+- **Superuser restriction** — Prevents superuser accounts from running jobs unless explicitly allowed.
+
+**Query path**: `apd/common_policies`
+
+Configure via `policy_as_code_vars` in extra_vars:
+
+```yaml
+policy_as_code_vars:
+  maintenance_window_start: "06:00"
+  maintenance_window_end: "22:00"
+  maintenance_window_timezone: "America/New_York"
+  allow_superuser: true
+```
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `maintenance_window_start` | Start of the allowed execution window (HH:MM, 24-hour) | Not set (no restriction) |
+| `maintenance_window_end` | End of the allowed execution window (HH:MM, 24-hour) | Not set (no restriction) |
+| `maintenance_window_timezone` | IANA timezone for the maintenance window | `UTC` |
+| `allow_superuser` | Allow superuser accounts to run jobs | `false` |
+
+## Why it matters
+
+- **Context-aware enforcement** — Complement AAP RBAC enforcement with additional context - incident freezes, maintenance windows, etc.
+- **Flexible scoping** — Apply policies at the organization, inventory, or job template level with per-scope configuration via extra_vars
+- **Separation of concerns** — Security and compliance teams can manage Rego policies independently from automation content
+
+## Presenter walkthrough
+
+1. Run **Infrastructure | OPA - Deploy Open Policy Agent** — accept the defaults or customize the namespace and image. After the job completes, confirm the OPA server URL in the output
+2. Apply the `apd/deny_all` policy to the demo organization in AAP (Access → Organizations → edit → Policy enforcement → set OPA query path to `apd/deny_all`)
+3. Run any job template in that organization — show that it is denied with the message "'Deny all' policy is in effect"
+4. Change the organization's policy to `apd/common_policies` — run a job as a regular user to show it is now allowed (no `policy_as_code_vars` configured, so the policy allows all jobs by default)
+5. Run the same job as a superuser (e.g. "admin") to demonstrate the superuser restriction
+6. Add `policy_as_code_vars` to the organization or job template's extra_vars with a maintenance window that excludes the current time — run the job to show it is denied with a message indicating the allowed window
+7. Adjust the maintenance window to include the current time and re-run to show it is allowed
+8. Optionally use **Infrastructure | OPA - Add Policy** to upload a custom policy via the REST API, demonstrating runtime policy updates without redeployment
+
+## Talking points
+
+- OPA is a CNCF-graduated project used across the cloud-native ecosystem for policy enforcement
+- Rego policies are declarative and testable — they can be version-controlled alongside automation content
+- AAP evaluates policies before job execution, not after — violations are caught before any changes are made
+- The same OPA server can enforce policies for multiple AAP instances or other systems (Kubernetes admission, API gateways, etc.)
+- Maintenance window and superuser restrictions are just examples — any attribute in the AAP job request payload can be used for policy decisions
+
+## Related demos
+
+| Demo | Description |
+|------|-------------|
+| [ROSA Cluster Lifecycle](./rosa-lifecycle.md) | Provision an OpenShift cluster on AWS to use as the OPA deployment target |
+| [OpenShift CNV](../../openshift/docs/openshift-cnv.md) | Run VMs on an existing OpenShift cluster |

--- a/infrastructure/opa/add-policy.yml
+++ b/infrastructure/opa/add-policy.yml
@@ -1,0 +1,71 @@
+---
+- name: OPA | Add Policy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    _opa_namespace: '{{ opa_namespace | default("opa") }}'
+    _opa_policy_name: '{{ opa_policy_name }}'
+    _opa_policy_text: '{{ opa_policy_text }}'
+
+  tasks:
+    - name: Validate required variables
+      ansible.builtin.assert:
+        that:
+          - opa_policy_name is defined
+          - opa_policy_name | length > 0
+          - opa_policy_text is defined
+          - opa_policy_text | length > 0
+        fail_msg: "Both opa_policy_name and opa_policy_text are required."
+
+    - name: Look up OPA route
+      kubernetes.core.k8s_info:
+        api_version: route.openshift.io/v1
+        kind: Route
+        name: opa
+        namespace: '{{ _opa_namespace }}'
+      register: _opa_route
+
+    - name: Verify OPA route exists
+      ansible.builtin.assert:
+        that:
+          - _opa_route.resources | length > 0
+        fail_msg: "No OPA route found in namespace {{ _opa_namespace }}. Deploy OPA first."
+
+    - name: Set OPA URL
+      ansible.builtin.set_fact:
+        _opa_url: 'https://{{ _opa_route.resources[0].spec.host }}'
+
+    - name: Display policy to upload
+      ansible.builtin.debug:
+        msg:
+          - "OPA server: {{ _opa_url }}"
+          - "Policy name: {{ _opa_policy_name }}"
+          - "Policy text:"
+          - "{{ _opa_policy_text }}"
+
+    - name: Upload policy to OPA
+      ansible.builtin.uri:
+        url: '{{ _opa_url }}/v1/policies/{{ _opa_policy_name }}'
+        method: PUT
+        body: '{{ _opa_policy_text }}'
+        body_format: raw
+        status_code: 200
+        validate_certs: false
+      register: _upload_result
+
+    - name: Display upload result
+      ansible.builtin.debug:
+        msg:
+          - "========================================="
+          - "Policy '{{ _opa_policy_name }}' uploaded successfully"
+          - "========================================="
+          - "OPA server: {{ _opa_url }}"
+          - "Policy endpoint: {{ _opa_url }}/v1/policies/{{ _opa_policy_name }}"
+          - "---"
+          - "NOTE: This policy is in memory only and will not survive an OPA server reboot"
+          - "========================================="
+
+...
+# vim: ft=yaml.ansible

--- a/infrastructure/opa/deploy-opa.yml
+++ b/infrastructure/opa/deploy-opa.yml
@@ -44,9 +44,7 @@
             name: opa-policy
             namespace: '{{ _opa_namespace }}'
             labels: '{{ _opa_labels }}'
-          data: '{{ _opa_policy_data }}'
-      register: _opa_configmap
-      when: _opa_policy_data | default({}) | length > 0
+          data: '{{ _opa_policy_data | default({}) }}'
 
     - name: Create OPA Deployment
       redhat.openshift.k8s:

--- a/infrastructure/opa/deploy-opa.yml
+++ b/infrastructure/opa/deploy-opa.yml
@@ -1,0 +1,176 @@
+---
+- name: OPA | Deploy Open Policy Agent
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    _opa_namespace: '{{ opa_namespace | default("opa") }}'
+    _opa_image: '{{ opa_image | default("docker.io/openpolicyagent/opa:latest-static") }}'
+    _opa_labels:
+      app: opa
+      app.kubernetes.io/name: opa
+      app.kubernetes.io/component: policy-engine
+      app.kubernetes.io/managed-by: ansible
+
+  tasks:
+    - name: Verify OpenShift cluster connectivity
+      kubernetes.core.k8s_cluster_info:
+      register: _cluster_info
+
+    - name: Display cluster connection info
+      ansible.builtin.debug:
+        msg: 'Connected to cluster at {{ _cluster_info.connection.host }}'
+
+    - name: Create OPA project
+      redhat.openshift.k8s:
+        api_version: project.openshift.io/v1
+        kind: Project
+        name: '{{ _opa_namespace }}'
+        state: present
+
+    - name: Load policy files from policies directory
+      ansible.builtin.set_fact:
+        _opa_policy_data: '{{ _opa_policy_data | default({}) | combine({item | basename: lookup("file", item)}) }}'
+      loop: '{{ query("fileglob", "policies/*.rego") }}'
+
+    - name: Create policy ConfigMap
+      redhat.openshift.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: opa-policy
+            namespace: '{{ _opa_namespace }}'
+            labels: '{{ _opa_labels }}'
+          data: '{{ _opa_policy_data }}'
+      register: _opa_configmap
+      when: _opa_policy_data | default({}) | length > 0
+
+    - name: Create OPA Deployment
+      redhat.openshift.k8s:
+        state: present
+        definition:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: opa
+            namespace: '{{ _opa_namespace }}'
+            labels: '{{ _opa_labels }}'
+          spec:
+            selector:
+              matchLabels:
+                app: opa
+            template:
+              metadata:
+                labels: '{{ _opa_labels }}'
+                annotations:
+                  policy-checksum: '{{ (_opa_policy_data | default({})) | to_json | hash("sha256") }}'
+              spec:
+                containers:
+                  - name: opa
+                    image: '{{ _opa_image }}'
+                    args: >-
+                      {{
+                        ['run', '--server', '--addr=0.0.0.0:8181', '--log-level=info']
+                        + (_opa_policy_data | default({}) | sort | map('regex_replace', '^', '/policies/') | list)
+                      }}
+                    ports:
+                      - containerPort: 8181
+                        name: http
+                        protocol: TCP
+                    livenessProbe:
+                      httpGet:
+                        path: /health
+                        port: http
+                      initialDelaySeconds: 10
+                      periodSeconds: 15
+                    readinessProbe:
+                      httpGet:
+                        path: /health
+                        port: http
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 128Mi
+                      limits:
+                        cpu: 500m
+                        memory: 256Mi
+                    volumeMounts:
+                      - name: opa-policy
+                        mountPath: /policies
+                        readOnly: true
+                volumes:
+                  - name: opa-policy
+                    configMap:
+                      name: opa-policy
+
+    - name: Create OPA Service
+      redhat.openshift.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: opa
+            namespace: '{{ _opa_namespace }}'
+            labels: '{{ _opa_labels }}'
+          spec:
+            selector:
+              app: opa
+            ports:
+              - name: http
+                port: 8181
+                targetPort: http
+                protocol: TCP
+
+    - name: Create OPA Route
+      redhat.openshift.openshift_route:
+        service: opa
+        namespace: '{{ _opa_namespace }}'
+        termination: edge
+        labels: '{{ _opa_labels }}'
+        state: present
+      register: _opa_route
+
+    - name: Wait for OPA rollout to complete
+      kubernetes.core.k8s_info:
+        api_version: apps/v1
+        kind: Deployment
+        name: opa
+        namespace: '{{ _opa_namespace }}'
+      register: _opa_deployment
+      retries: 30
+      delay: 10
+      until:
+        - _opa_deployment.resources | length > 0
+        - (_opa_deployment.resources[0].status.readyReplicas | default(0) | int) >= 1
+
+    - name: Configure AAP Policy as Code settings
+      ansible.controller.settings:
+        settings:
+          OPA_HOST: '{{ _opa_route.result.spec.host }}'
+          OPA_PORT: 443
+          OPA_SSL: true
+          OPA_AUTH_TYPE: None
+          OPA_AUTH_TOKEN: ''
+
+    - name: Display OPA deployment information
+      ansible.builtin.debug:
+        msg:
+          - "========================================="
+          - "OPA Server Deployed on OpenShift"
+          - "========================================="
+          - "Namespace: {{ _opa_namespace }}"
+          - "Image: {{ _opa_image }}"
+          - "---"
+          - "Route: https://{{ _opa_route.result.spec.host }}"
+          - "API endpoint: https://{{ _opa_route.result.spec.host }}/v1"
+          - "Health check: https://{{ _opa_route.result.spec.host }}/health"
+          - "========================================="
+
+...
+# vim: ft=yaml.ansible

--- a/infrastructure/opa/policies/common_policies.rego
+++ b/infrastructure/opa/policies/common_policies.rego
@@ -1,0 +1,115 @@
+package apd
+
+import rego.v1
+
+pac_vars := object.get(input.extra_vars, "policy_as_code_vars", {})
+
+# =============================================================================
+# Maintenance window
+# =============================================================================
+
+_mw_start_str := object.get(pac_vars, "maintenance_window_start", null)
+_mw_end_str := object.get(pac_vars, "maintenance_window_end", null)
+_mw_tz := object.get(pac_vars, "maintenance_window_timezone", "UTC")
+
+_mw_parse_minutes(hhmm) := (to_number(parts[0]) * 60) + to_number(parts[1]) if {
+  parts := split(hhmm, ":")
+  count(parts) == 2
+  to_number(parts[0]) >= 0
+  to_number(parts[0]) <= 23
+  to_number(parts[1]) >= 0
+  to_number(parts[1]) <= 59
+}
+
+_mw_start_min := _mw_parse_minutes(_mw_start_str)
+_mw_end_min := _mw_parse_minutes(_mw_end_str)
+
+_mw_clock := time.clock([time.parse_rfc3339_ns(input.created), _mw_tz])
+_mw_now_min := (_mw_clock[0] * 60) + _mw_clock[1]
+
+_mw_configured if {
+  _mw_start_str != null
+  _mw_end_str != null
+}
+
+violations contains msg if {
+  _mw_configured
+  not _mw_start_min
+  msg := sprintf("Invalid maintenance_window_start value '%s' — use HH:MM format (00:00-23:59)", [_mw_start_str])
+}
+
+violations contains msg if {
+  _mw_configured
+  not _mw_end_min
+  msg := sprintf("Invalid maintenance_window_end value '%s' — use HH:MM format (00:00-23:59)", [_mw_end_str])
+}
+
+_mw_wrapping if {
+  _mw_start_min > _mw_end_min
+}
+
+_mw_in_window if {
+  not _mw_wrapping
+  _mw_now_min >= _mw_start_min
+  _mw_now_min < _mw_end_min
+}
+
+_mw_in_window if {
+  _mw_wrapping
+  _mw_now_min >= _mw_start_min
+}
+
+_mw_in_window if {
+  _mw_wrapping
+  _mw_now_min < _mw_end_min
+}
+
+violations contains msg if {
+  _mw_configured
+  _mw_start_min == _mw_end_min
+  msg := sprintf(
+    "maintenance_window_start and maintenance_window_end are both '%s' — start and end times must differ",
+    [_mw_start_str],
+  )
+}
+
+violations contains msg if {
+  _mw_configured
+  _mw_start_min
+  _mw_end_min
+  _mw_start_min != _mw_end_min
+  not _mw_in_window
+  msg := sprintf(
+    "Job execution is only allowed between %s and %s (%s)",
+    [_mw_start_str, _mw_end_str, _mw_tz],
+  )
+}
+
+# =============================================================================
+# Deny superuser accounts
+# =============================================================================
+
+violations contains msg if {
+  input.created_by.is_superuser
+  not object.get(pac_vars, "allow_superuser", false) in {true, "true"}
+  msg := sprintf(
+    "Superuser account '%v' is not allowed to run jobs — use an account with a different role",
+    [input.created_by.username],
+  )
+}
+
+# =============================================================================
+# Combined result
+# =============================================================================
+
+default common_policies := {
+  "allowed": true,
+  "violations": [],
+}
+
+common_policies := {
+  "allowed": false,
+  "violations": [v | some v in violations],
+} if {
+  count(violations) > 0
+}

--- a/infrastructure/opa/policies/deny_all.rego
+++ b/infrastructure/opa/policies/deny_all.rego
@@ -1,0 +1,8 @@
+package apd
+
+import rego.v1
+
+deny_all := {
+  "allowed": false,
+  "violations": ["'Deny all' policy is in effect, contact the AAP administrator for details"],
+}

--- a/infrastructure/setup.yml
+++ b/infrastructure/setup.yml
@@ -307,6 +307,81 @@ controller_templates:
       - OpenShift Credential
       - AAP Credential
 
+  - name: Infrastructure | OPA - Deploy Open Policy Agent
+    description: >-
+      Deploys Open Policy Agent on OpenShift and configures AAP's
+      Policy as Code settings to use the new OPA server. All .rego
+      policy files are loaded into a ConfigMap and mounted into the
+      OPA container.
+    job_type: run
+    organization: Ansible Product Demos (APD)
+    credentials:
+      - OpenShift Credential
+      - AAP Credential
+    project: Ansible Product Demos
+    playbook: infrastructure/opa/deploy-opa.yml
+    inventory: Ansible Product Demos Inventory
+    notification_templates_started: Telemetry
+    notification_templates_success: Telemetry
+    notification_templates_error: Telemetry
+    survey_enabled: true
+    survey:
+      name: ''
+      description: ''
+      spec:
+        - question_name: OPA namespace
+          question_description: >-
+            OpenShift project/namespace for the OPA deployment
+          type: text
+          variable: opa_namespace
+          required: true
+          default: opa
+        - question_name: OPA container image
+          type: text
+          variable: opa_image
+          required: true
+          default: docker.io/openpolicyagent/opa:latest-static
+
+  - name: Infrastructure | OPA - Add Policy
+    description: >-
+      Uploads a Rego policy to OPA via the REST API. Policies added
+      this way are stored in memory only and will not survive an OPA
+      pod restart.
+    job_type: run
+    organization: Ansible Product Demos (APD)
+    credentials:
+      - OpenShift Credential
+    project: Ansible Product Demos
+    playbook: infrastructure/opa/add-policy.yml
+    inventory: Ansible Product Demos Inventory
+    notification_templates_started: Telemetry
+    notification_templates_success: Telemetry
+    notification_templates_error: Telemetry
+    survey_enabled: true
+    survey:
+      name: ''
+      description: ''
+      spec:
+        - question_name: OPA namespace
+          question_description: >-
+            OpenShift project/namespace where OPA is deployed
+          type: text
+          variable: opa_namespace
+          required: true
+          default: opa
+        - question_name: Policy name
+          question_description: >-
+            Unique identifier for the policy (e.g. aap_syntax_check)
+          type: text
+          variable: opa_policy_name
+          required: true
+        - question_name: Rego policy text
+          question_description: >-
+            Rego policy code to upload to OPA
+          type: textarea
+          variable: opa_policy_text
+          required: true
+
 controller_workflows:
   - name: Infrastructure | ROSA - Lifecycle (Create)
     description: >-

--- a/infrastructure/setup.yml
+++ b/infrastructure/setup.yml
@@ -307,7 +307,7 @@ controller_templates:
       - OpenShift Credential
       - AAP Credential
 
-  - name: Infrastructure | OPA - Deploy Open Policy Agent
+  - name: Infrastructure | OPA - Deploy Open Policy Agent on OpenShift
     description: >-
       Deploys Open Policy Agent on OpenShift and configures AAP's
       Policy as Code settings to use the new OPA server. All .rego


### PR DESCRIPTION
deploys a non-production OPA instance on an existing OpenShift cluster using the APD OpenShift credential.  includes two rego policies for demo purposes

* apd/deny_all - prevents anything from executing.  use for "maintenance mode" or other scenarios when jobs should not be executed.
* apd/common_policies - includes a policy that prevents superuser from executing jobs (for audit purposes), and a policy for only allowing job execution during a defined window of time.

also includes a job template for uploading a rego policy to the OPA server.  it uses the OPA API to add the policy to running memory, but it will not persist across a restart of the OPA server.