### PR TITLE
feat: switch AO install to stable release channel

### DIFF
--- a/infrastructure/ao/install.yml
+++ b/infrastructure/ao/install.yml
@@ -5,7 +5,7 @@
   gather_facts: false
 
   vars:
-    ao_channel: "{{ ao_operator_channel | default('candidate') }}"
+    ao_channel: "{{ ao_operator_channel | default('stable') }}"
     ao_namespace: automation-orchestrator
 
     _k8s_host: "{{ lookup('env', 'K8S_AUTH_HOST') | default('', true) }}"

--- a/infrastructure/setup.yml
+++ b/infrastructure/setup.yml
@@ -247,23 +247,8 @@ controller_templates:
     notification_templates_success: Telemetry
     notification_templates_error: Telemetry
     timeout: 3600
-    survey_enabled: true
-    survey:
-      name: ''
-      description: ''
-      spec:
-        - question_name: Release Channel
-          question_description: >-
-            stable for production-grade releases; early-access for evaluation only
-            (no SLA, no upgrade path).
-          type: multiplechoice
-          variable: ao_operator_channel
-          required: true
-          default: candidate
-          choices:
-            - candidate
-            - stable
-            - early-access
+    extra_vars:
+      ao_operator_channel: stable
     credentials:
       - OpenShift Credential
 


### PR DESCRIPTION
  ## Summary
  - Removes the release channel survey from the AO Install job template
  - Hardcodes the operator channel to `stable` now that AO is GA
  - Updates the playbook default from `candidate` to `stable`

  ## Changes
  - `infrastructure/setup.yml` — replaced survey with `extra_vars: ao_operator_channel: stable`
  - `infrastructure/ao/install.yml` — updated default fallback from `candidate` to `stable`