### PR TITLE
fix: configure AO network access so the AAP gateway can reach it

### DIFF
--- a/infrastructure/ao/install.yml
+++ b/infrastructure/ao/install.yml
@@ -198,3 +198,5 @@
             }}
           loop_control:
             label: "{{ item }}"
+
+- ansible.builtin.import_playbook: network-access.yml

--- a/infrastructure/ao/install.yml
+++ b/infrastructure/ao/install.yml
@@ -199,4 +199,5 @@
           loop_control:
             label: "{{ item }}"
 
-- ansible.builtin.import_playbook: network-access.yml
+- name: Configure Automation Orchestrator network access
+  ansible.builtin.import_playbook: network-access.yml

--- a/infrastructure/ao/network-access.yml
+++ b/infrastructure/ao/network-access.yml
@@ -10,12 +10,11 @@
     ao_extra_hosts: []
 
     # AAP gateway hostname, from the AAP credential on the job template.
-    # CONTROLLER_HOST/TOWER_HOST are URLs; the allow-list takes bare hostnames.
+    # CONTROLLER_HOST is a URL; the allow-list takes a bare hostname.
     ao_aap_hostname: >-
       {{ (aap_hostname
           | default(lookup('env', 'AAP_HOSTNAME'), true)
           | default(lookup('env', 'CONTROLLER_HOST'), true)
-          | default(lookup('env', 'TOWER_HOST'), true)
           | default('', true))
          | trim
          | ansible.builtin.urlsplit('hostname')

--- a/infrastructure/ao/network-access.yml
+++ b/infrastructure/ao/network-access.yml
@@ -1,0 +1,141 @@
+---
+- name: Configure Automation Orchestrator network access
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    ao_namespace: automation-orchestrator
+    ao_instance: automation-orchestrator
+    ao_extra_hosts: []
+
+    # AAP gateway hostname, from the AAP credential on the job template.
+    # CONTROLLER_HOST/TOWER_HOST are URLs; the allow-list takes bare hostnames.
+    ao_aap_hostname: >-
+      {{ (aap_hostname
+          | default(lookup('env', 'CONTROLLER_HOST'), true)
+          | default(lookup('env', 'TOWER_HOST'), true)
+          | default('', true))
+         | trim
+         | regex_replace('^[a-zA-Z][a-zA-Z0-9+.-]*://', '')
+         | regex_replace('/.*$', '')
+         | regex_replace(':[0-9]+$', '') }}
+
+    ao_backend: "{{ ao_instance }}-backend"
+    ao_deployments:
+      - "{{ ao_instance }}-backend"
+      - "{{ ao_instance }}-worker"
+      - "{{ ao_instance }}-background-worker"
+
+    ao_env_all:
+      - name: APP_INTEGRATION_URL_ALLOWED_HOSTS
+        value: "{{ ao_allowed_hosts | to_json }}"
+    ao_env_backend:
+      - name: APP_OIDC_ALLOW_PRIVATE_NETWORKS
+        value: "true"
+
+    ao_restart_stamp: "{{ now(utc=true, fmt='%Y-%m-%dT%H:%M:%SZ') }}"
+
+  tasks:
+    - name: Verify the AAP gateway hostname is known
+      ansible.builtin.assert:
+        that:
+          - ao_aap_hostname | length > 0
+        fail_msg: >-
+          Pass -e aap_hostname=aap.example.com, or attach a 'Red Hat Ansible
+          Automation Platform' credential so CONTROLLER_HOST is set.
+
+    - name: Get the Automation Orchestrator Route
+      kubernetes.core.k8s_info:
+        api_version: route.openshift.io/v1
+        kind: Route
+        name: "{{ ao_instance }}"
+        namespace: "{{ ao_namespace }}"
+      register: ao_route
+      until: ao_route.resources | default([]) | length > 0
+      retries: 10
+      delay: 6
+
+    - name: Get the Automation Orchestrator application Deployments
+      kubernetes.core.k8s_info:
+        api_version: apps/v1
+        kind: Deployment
+        name: "{{ item }}"
+        namespace: "{{ ao_namespace }}"
+      register: ao_deploy
+      until: ao_deploy.resources | default([]) | length > 0
+      retries: 10
+      delay: 6
+      loop: "{{ ao_deployments }}"
+
+    - name: Build the integration allow-list
+      ansible.builtin.set_fact:
+        ao_allowed_hosts: >-
+          {{ ([ao_aap_hostname] + [ao_route.resources[0].spec.host] + ao_extra_hosts)
+             | unique | list }}
+
+    # env merges on 'name', so operator-set variables are left alone. The
+    # allow-list must reach both workers, not just the backend.
+    - name: Allow private-network OIDC and allowlist the AAP and AO hosts
+      kubernetes.core.k8s:
+        state: patched
+        merge_type: strategic-merge
+        api_version: apps/v1
+        kind: Deployment
+        name: "{{ item.metadata.name }}"
+        namespace: "{{ ao_namespace }}"
+        wait: true
+        wait_timeout: 300
+        definition:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: "{{ item.spec.template.spec.containers[0].name }}"
+                    env: >-
+                      {{ ao_env_all
+                         + (ao_env_backend if item.metadata.name == ao_backend else []) }}
+      notify: restart automation orchestrator
+      loop: "{{ ao_deploy.results | map(attribute='resources') | flatten }}"
+      loop_control:
+        label: "{{ item.metadata.name }}"
+
+    - name: Show the allow-list
+      ansible.builtin.debug:
+        var: ao_allowed_hosts
+
+  handlers:
+    # The three patched above roll themselves; this catches ui, redis
+    # and temporal so nothing keeps the old OIDC client behavior.
+    - name: List the rest of the Deployments in the instance
+      kubernetes.core.k8s_info:
+        api_version: apps/v1
+        kind: Deployment
+        namespace: "{{ ao_namespace }}"
+        label_selectors:
+          - "app.kubernetes.io/instance={{ ao_instance }}"
+      register: ao_all
+      listen: restart automation orchestrator
+
+    - name: Restart the rest of the Deployments
+      kubernetes.core.k8s:
+        state: patched
+        merge_type: strategic-merge
+        api_version: apps/v1
+        kind: Deployment
+        name: "{{ item.metadata.name }}"
+        namespace: "{{ ao_namespace }}"
+        wait: true
+        wait_timeout: 300
+        definition:
+          spec:
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/restartedAt: "{{ ao_restart_stamp }}"
+      loop: >-
+        {{ ao_all.resources | default([])
+           | rejectattr('metadata.name', 'in', ao_deployments) | list }}
+      loop_control:
+        label: "{{ item.metadata.name }}"
+      listen: restart automation orchestrator

--- a/infrastructure/ao/network-access.yml
+++ b/infrastructure/ao/network-access.yml
@@ -104,6 +104,26 @@
       ansible.builtin.debug:
         var: ao_allowed_hosts
 
+    - name: Get admin password
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Secret
+        name: automation-orchestrator-initial-admin-password
+        namespace: "{{ ao_namespace }}"
+      register: admin_secret
+      ignore_errors: true
+
+    - name: Display access information
+      ansible.builtin.debug:
+        msg:
+          - "Automation Orchestrator deployment complete."
+          - "URL: https://{{ ao_route.resources[0].spec.host }}"
+          - "Username: admin"
+          - "Password: {{ admin_secret.resources[0].data.password | b64decode }}"
+          - "Note: login may fail for a minute or two after deploy — retry if it errors."
+      when:
+        - admin_secret.resources | default([]) | length > 0
+
   handlers:
     # The three patched above roll themselves; this catches ui, redis
     # and temporal so nothing keeps the old OIDC client behavior.

--- a/infrastructure/ao/network-access.yml
+++ b/infrastructure/ao/network-access.yml
@@ -13,13 +13,13 @@
     # CONTROLLER_HOST/TOWER_HOST are URLs; the allow-list takes bare hostnames.
     ao_aap_hostname: >-
       {{ (aap_hostname
+          | default(lookup('env', 'AAP_HOSTNAME'), true)
           | default(lookup('env', 'CONTROLLER_HOST'), true)
           | default(lookup('env', 'TOWER_HOST'), true)
           | default('', true))
          | trim
-         | regex_replace('^[a-zA-Z][a-zA-Z0-9+.-]*://', '')
-         | regex_replace('/.*$', '')
-         | regex_replace(':[0-9]+$', '') }}
+         | ansible.builtin.urlsplit('hostname')
+         | default('', true) }}
 
     ao_backend: "{{ ao_instance }}-backend"
     ao_deployments:
@@ -42,8 +42,9 @@
         that:
           - ao_aap_hostname | length > 0
         fail_msg: >-
-          Pass -e aap_hostname=aap.example.com, or attach a 'Red Hat Ansible
-          Automation Platform' credential so CONTROLLER_HOST is set.
+          Attach a 'Red Hat Ansible Automation Platform' credential so
+          CONTROLLER_HOST is set, or pass -e aap_hostname=<url> (e.g.
+          https://aap.example.com).
 
     - name: Get the Automation Orchestrator Route
       kubernetes.core.k8s_info:

--- a/infrastructure/setup.yml
+++ b/infrastructure/setup.yml
@@ -534,7 +534,6 @@ controller_workflows:
     notification_templates_started: Telemetry
     notification_templates_success: Telemetry
     notification_templates_error: Telemetry
-    ask_variables_on_launch: true
     simplified_workflow_nodes:
       - identifier: Install AO
         unified_job_template: Infrastructure | Automation Orchestrator | Install

--- a/infrastructure/setup.yml
+++ b/infrastructure/setup.yml
@@ -267,6 +267,24 @@ controller_templates:
     credentials:
       - OpenShift Credential
 
+  - name: Infrastructure | AO Network Configuration | Install
+    description: >-
+      Allow-lists the AAP gateway and AO route hostnames on Automation
+      Orchestrator's integration URL allow-list and enables private-network
+      OIDC, then restarts the instance so the change takes effect.
+    job_type: run
+    inventory: Ansible Product Demos Inventory
+    project: "Ansible Product Demos"
+    playbook: "infrastructure/ao/network-access.yml"
+    execution_environment: AO Execution Environment
+    notification_templates_started: Telemetry
+    notification_templates_success: Telemetry
+    notification_templates_error: Telemetry
+    ask_variables_on_launch: true
+    credentials:
+      - OpenShift Credential
+      - AAP Credential
+
   - name: Infrastructure | HashiCorp Vault
     job_type: run
     inventory: Ansible Product Demos Inventory
@@ -506,3 +524,21 @@ controller_workflows:
           feedback: >-
             ROSA cluster destruction failed. Manual cleanup may be required.
             Check AWS console for orphaned resources (VPCs, IAM roles, CloudFormation stacks).
+
+  - name: Infrastructure | Automation Orchestrator | Install Workflow
+    description: >-
+      Deploys Automation Orchestrator via aapctl, then configures its
+      network access allow-list and OIDC settings so the AAP gateway
+      can reach it.
+    organization: Ansible Product Demos (APD)
+    notification_templates_started: Telemetry
+    notification_templates_success: Telemetry
+    notification_templates_error: Telemetry
+    ask_variables_on_launch: true
+    simplified_workflow_nodes:
+      - identifier: Install AO
+        unified_job_template: Infrastructure | Automation Orchestrator | Install
+        success_nodes:
+          - Configure Network Access
+      - identifier: Configure Network Access
+        unified_job_template: Infrastructure | AO Network Configuration | Install

--- a/infrastructure/setup.yml
+++ b/infrastructure/setup.yml
@@ -237,7 +237,8 @@ controller_templates:
     description: >-
       Deploys Automation Orchestrator on an existing OpenShift cluster using
       aapctl. Installs CloudNativePG operator, PostgreSQL database, and the
-      AO operator in a single automated step.
+      AO operator, then configures network access so the AAP gateway can
+      reach it.
     job_type: run
     inventory: Ansible Product Demos Inventory
     project: "Ansible Product Demos"
@@ -251,6 +252,7 @@ controller_templates:
       ao_operator_channel: stable
     credentials:
       - OpenShift Credential
+      - AAP Credential
 
   - name: Infrastructure | Automation Orchestrator | Uninstall
     description: >-
@@ -524,20 +526,3 @@ controller_workflows:
           feedback: >-
             ROSA cluster destruction failed. Manual cleanup may be required.
             Check AWS console for orphaned resources (VPCs, IAM roles, CloudFormation stacks).
-
-  - name: Infrastructure | Automation Orchestrator | Install Workflow
-    description: >-
-      Deploys Automation Orchestrator via aapctl, then configures its
-      network access allow-list and OIDC settings so the AAP gateway
-      can reach it.
-    organization: Ansible Product Demos (APD)
-    notification_templates_started: Telemetry
-    notification_templates_success: Telemetry
-    notification_templates_error: Telemetry
-    simplified_workflow_nodes:
-      - identifier: Install AO
-        unified_job_template: Infrastructure | Automation Orchestrator | Install
-        success_nodes:
-          - Configure Network Access
-      - identifier: Configure Network Access
-        unified_job_template: Infrastructure | AO Network Configuration | Install


### PR DESCRIPTION
  # Summary

  - Fixes AO's OIDC integration by allow-listing the AAP gateway and AO route hostnames and enabling private-network OIDC (infrastructure/ao/network-access.yml), restarting the AO deployments so the change takes effect.
  - Folds this into Infrastructure | Automation Orchestrator | Install via import_playbook, so the single existing job template people already run (per what was shown in the specialist call) does both the install and the network fix (no new workflow to discover)
  - Adds a standalone Infrastructure | AO Network Configuration | Install job template for re-running just the network fix without redoing the full aapctl install (requires OpenShift + AAP credentials attached).
  - Reprints access info (URL/username/password) at the end of the run so it's visible without scrolling back up.

 ##  Why

  The AAP gateway couldn't reach AO's OIDC integration endpoints because its hostname (and AO's own route) weren't on AO's APP_INTEGRATION_URL_ALLOWED_HOSTS allow-list, and private-network OIDC wasn't enabled.

  ## Test plan

  - [x] Verified against a live cluster by pointing the project's SCM branch at this branch and syncing
  - [x] Ran APD | Single demo setup → infrastructure and confirmed AO installs and network access is configured in one job