### PR TITLE
Fix infrastructure setup failure from Config Drift workflow

### DIFF
--- a/infrastructure/docs/config-drift.md
+++ b/infrastructure/docs/config-drift.md
@@ -18,12 +18,12 @@ Two parts: **one-time setup**, then **show the demo**.
 ### Part 1 — One-time setup
 
 1. Sync the **Ansible Product Demos** project from your fork branch.
-2. Run **APD | Single demo setup** with category `infrastructure` (cloud stack must already exist, or the workflow deploys it for you).
+2. Run **APD | Single demo setup** with category `infrastructure`.
 3. Launch **Infrastructure | Config Drift - Full Setup** and complete the survey (region, owner, environment).
 
 That single workflow:
 
-- Checks whether `aws_rhel8` and `aws_rhel9` are in inventory — if not, runs **Deploy Cloud Stack in AWS** automatically
+- Checks whether `aws_rhel8` and `aws_rhel9` are in inventory — if not, stops with a message to run **Deploy Cloud Stack in AWS** first
 - Provisions the Kafka queue (`aws_kafka`)
 - Syncs AWS inventory
 - Deploys auditd + Filebeat on `aws_rhel*` with Kafka output
@@ -59,7 +59,7 @@ Same EDA → remediation flow follows within ~20 seconds.
 
 ## Prerequisites
 
-- **Deploy Cloud Stack in AWS** already run, *or* let the Full Setup workflow deploy it for you
+- **Deploy Cloud Stack in AWS** already run (`aws_rhel8`, `aws_rhel9` in inventory)
 - **APD | Single demo setup** — category `infrastructure`
 - **RHSM Registration** credential — org ID and activation key (see **LINUX | Register RHEL with RHSM**)
 - **Automation Decisions (EDA)** on AAP
@@ -69,7 +69,7 @@ Same EDA → remediation flow follows within ~20 seconds.
 
 Launch **Infrastructure | Config Drift - Full Setup** — a single workflow that:
 
-1. Verifies `aws_rhel8` and `aws_rhel9` are in inventory (or runs **Deploy Cloud Stack in AWS** if missing)
+1. Verifies `aws_rhel8` and `aws_rhel9` are in inventory (fails with guidance if missing)
 2. Provisions Kafka (`aws_kafka`)
 3. Syncs AWS inventory
 4. Deploys auditd + Filebeat with Kafka output on `aws_rhel*`
@@ -78,19 +78,18 @@ Launch **Infrastructure | Config Drift - Full Setup** — a single workflow that
 ```mermaid
 flowchart LR
   check[Check Cloud Stack]
-  deploy[Deploy Cloud Stack]
+  feedback[Cloud stack required]
   kafka[Provision Kafka]
   sync[Sync Inventory]
   filebeat[Deploy Filebeat]
   eda[Setup EDA]
 
   check -->|success| kafka
-  check -->|failure| deploy
-  deploy --> kafka
+  check -->|failure| feedback
   kafka --> sync --> filebeat --> eda
 ```
 
-In the AAP workflow visualizer, the main path runs left to right. **Deploy Cloud Stack** appears on the failure branch below **Check Cloud Stack** when workers are missing.
+In the AAP workflow visualizer, the main path runs left to right. When workers are missing, **Check Cloud Stack** fails to a feedback node that tells you to run **Deploy Cloud Stack in AWS** first.
 
 Survey prompts: AWS region, owner tag, and environment (same as cloud stack deploy).
 

--- a/infrastructure/setup.yml
+++ b/infrastructure/setup.yml
@@ -664,8 +664,8 @@ controller_templates:
   - name: "Infrastructure | Config Drift - Check Cloud Stack"
     description: >-
       Verifies aws_rhel8 and aws_rhel9 exist in inventory before config drift
-      setup. Used by the Full Setup workflow; fails when the cloud stack must
-      be deployed first.
+      setup. Used by the Full Setup workflow; fails when Deploy Cloud Stack in
+      AWS must be run first.
     job_type: run
     organization: Ansible Product Demos (APD)
     inventory: Ansible Product Demos Inventory
@@ -817,9 +817,10 @@ controller_workflows:
 
   - name: Infrastructure | Config Drift - Full Setup
     description: >-
-      One-shot config drift pipeline setup: verify or deploy cloud stack RHEL
-      workers, provision Kafka, sync inventory, deploy auditd and Filebeat with
-      Kafka output, and activate the EDA rulebook. Run Introduce SSHD Drift
+      One-shot config drift pipeline setup: verify cloud stack RHEL workers are
+      in inventory, provision Kafka, sync inventory, deploy auditd and Filebeat
+      with Kafka output, and activate the EDA rulebook. Run Deploy Cloud Stack
+      in AWS first if aws_rhel8/aws_rhel9 are missing. Run Introduce SSHD Drift
       separately for the live demo.
     organization: Ansible Product Demos (APD)
     notification_templates_started: Telemetry
@@ -871,23 +872,25 @@ controller_workflows:
           success_nodes:
             - identifier: Provision Kafka
           failure_nodes:
-            - identifier: Deploy Cloud Stack
+            - identifier: Cloud Stack Required
         unified_job_template:
           name: Infrastructure | Config Drift - Check Cloud Stack
           organization:
             name: Ansible Product Demos (APD)
             type: organization
           type: job_template
-      - identifier: Deploy Cloud Stack
-        related:
-          success_nodes:
-            - identifier: Provision Kafka
+      - identifier: Cloud Stack Required
         unified_job_template:
-          name: Deploy Cloud Stack in AWS
+          name: SUBMIT FEEDBACK
           organization:
             name: Ansible Product Demos (APD)
             type: organization
-          type: workflow_job_template
+          type: job_template
+        extra_data:
+          feedback: >-
+            aws_rhel8 and aws_rhel9 were not found in inventory. Run Deploy
+            Cloud Stack in AWS first, then re-launch Infrastructure | Config
+            Drift - Full Setup.
       - identifier: Provision Kafka
         related:
           success_nodes:


### PR DESCRIPTION
## Summary
- Replace the nested `Deploy Cloud Stack in AWS` workflow node in **Infrastructure | Config Drift - Full Setup** with a `SUBMIT FEEDBACK` node
- Infrastructure-only **APD | Single demo setup** no longer fails on fresh controllers when the cloud workflow has not been created yet
- Update config drift docs to state cloud stack is a prerequisite (run **Deploy Cloud Stack in AWS** before Full Setup)

## Context
PR #346 added a failure branch that referenced `Deploy Cloud Stack in AWS` as a `workflow_job_template`. That template is defined in `cloud/setup.yml`, so infrastructure-only setup fails with:

```
Unable to Find unified_job_template: {'type': 'workflow_job_template', 'organization': 2}
```

## Test plan
- [ ] On a fresh controller, run **APD | Single demo setup** with category `infrastructure` — should complete successfully
- [ ] Launch **Infrastructure | Config Drift - Full Setup** without cloud workers — should fail at Check Cloud Stack with feedback to run **Deploy Cloud Stack in AWS**
- [ ] After deploying the cloud stack, re-run Full Setup — Kafka, Filebeat, and EDA steps should proceed normally


Made with [Cursor](https://cursor.com)