### PR TITLE
Fix S3 VPC report bucket naming for multi-account demos

### DIFF
--- a/collections/ansible_collections/demo/cloud/roles/build_report_s3/README.md
+++ b/collections/ansible_collections/demo/cloud/roles/build_report_s3/README.md
@@ -23,12 +23,13 @@ Repo playbook: [`cloud/cloud_report.yml`](../../../../../../cloud/cloud_report.y
 
 ## Role Variables
 
-Defaults live in `vars/main.yml`.
+Defaults live in `defaults/main.yml`.
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `reports_aws_bucket_name` | `aws-cloud-report` | S3 bucket created/configured as a static website |
-| `reports_aws_region` | `us-west-1` | AWS region for the bucket |
+| `reports_aws_bucket_prefix` | first 4 chars of `AWS_ACCESS_KEY_ID` (lowercased) | Used to derive a globally unique bucket name |
+| `reports_aws_bucket_name` | `{{ reports_aws_bucket_prefix }}-reports` | S3 bucket created/configured as a static website |
+| `reports_aws_region` | `us-east-1` | AWS region for the bucket |
 
 ## Entry points
 

--- a/collections/ansible_collections/demo/cloud/roles/build_report_s3/README.md
+++ b/collections/ansible_collections/demo/cloud/roles/build_report_s3/README.md
@@ -17,7 +17,7 @@ Repo playbook: [`cloud/cloud_report.yml`](../../../../../../cloud/cloud_report.y
 
 - ansible-core >= 2.16.0
 - Target: `localhost`
-- `amazon.aws` collection (`s3_bucket`, `s3_object`, `s3_object_info`)
+- `amazon.aws` collection (`aws_caller_info`, `s3_bucket`, `s3_object`, `s3_object_info`)
 - `community.aws` collection (`s3_website`, `s3_sync`)
 - AWS credentials with permission to create/configure S3 buckets and objects
 
@@ -27,8 +27,7 @@ Defaults live in `defaults/main.yml`.
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `reports_aws_bucket_prefix` | first 4 chars of `AWS_ACCESS_KEY_ID` (lowercased) | Used to derive a globally unique bucket name |
-| `reports_aws_bucket_name` | `{{ reports_aws_bucket_prefix }}-reports` | S3 bucket created/configured as a static website |
+| `reports_aws_bucket_name` | `reports-pd-<AWS account ID>` (resolved at runtime) | S3 bucket created/configured as a static website |
 | `reports_aws_region` | `us-east-1` | AWS region for the bucket |
 
 ## Entry points

--- a/collections/ansible_collections/demo/cloud/roles/build_report_s3/defaults/main.yml
+++ b/collections/ansible_collections/demo/cloud/roles/build_report_s3/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+reports_aws_region: us-east-1
+reports_aws_bucket_prefix: "{{ lookup('ansible.builtin.env', 'AWS_ACCESS_KEY_ID')[1:5] | lower }}"
+reports_aws_bucket_name: "{{ reports_aws_bucket_prefix }}-reports"

--- a/collections/ansible_collections/demo/cloud/roles/build_report_s3/defaults/main.yml
+++ b/collections/ansible_collections/demo/cloud/roles/build_report_s3/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 reports_aws_region: us-east-1
-reports_aws_bucket_prefix: "{{ lookup('ansible.builtin.env', 'AWS_ACCESS_KEY_ID')[1:5] | lower }}"
-reports_aws_bucket_name: "{{ reports_aws_bucket_prefix }}-reports"
+# When empty, the role derives reports-pd-<AWS account ID> at runtime.
+reports_aws_bucket_name: ""

--- a/collections/ansible_collections/demo/cloud/roles/build_report_s3/tasks/main.yml
+++ b/collections/ansible_collections/demo/cloud/roles/build_report_s3/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: Resolve report bucket name from AWS account ID
+  when: not reports_aws_bucket_name
+  block:
+    - name: Get AWS account ID
+      amazon.aws.aws_caller_info:
+      register: reports_aws_caller_info
+
+    - name: Set report bucket name
+      ansible.builtin.set_fact:
+        reports_aws_bucket_name: "reports-pd-{{ reports_aws_caller_info.account }}"
+
 - name: Create report bucket
   amazon.aws.s3_bucket:
     name: "{{ reports_aws_bucket_name }}"

--- a/collections/ansible_collections/demo/cloud/roles/build_report_s3/vars/main.yml
+++ b/collections/ansible_collections/demo/cloud/roles/build_report_s3/vars/main.yml
@@ -1,3 +1,0 @@
----
-reports_aws_bucket_name: "aws-cloud-report"
-reports_aws_region: "us-west-1"


### PR DESCRIPTION
## Summary
- Replace the hardcoded `aws-cloud-report` bucket name in `demo.cloud.build_report_s3` with a per-account default derived at runtime via `aws_caller_info` (`reports-pd-<AWS account ID>`).
- Move bucket/region settings from role `vars/` to `defaults/` so playbooks and job template extra vars can override them again.
- Fixes 403 `HeadBucket` and 409 `BucketAlreadyExists` failures when multiple demo users run the VPC Report job against different AWS accounts.

## Test plan
- [x] Sync AAP project from `IPvSean/product-demos` branch `fix/build-report-s3-bucket-name`
- [x] Run **Cloud | AWS | VPC Report** and confirm bucket creation succeeds with `reports-pd-<account-id>`
- [x] Confirm report is reachable at the printed S3 website URL
- [ ] Have a second AWS account rerun the job and confirm it gets its own bucket (no 403/409)