### PR TITLE
Fix Linux compliance report and enforce on cloud stack RHEL 8

### DIFF
--- a/collections/ansible_collections/demo/cloud/roles/ensure_rhel8_python/tasks/main.yml
+++ b/collections/ansible_collections/demo/cloud/roles/ensure_rhel8_python/tasks/main.yml
@@ -1,27 +1,30 @@
 ---
 # ansible-core 2.16+ still requires Python 3.8+ on managed nodes. RHEL 8
 # platform-python is 3.6; install and pin python3.9 before module execution.
-- name: Gather distribution facts when needed for RHEL 8 check
-  ansible.builtin.setup:
-    gather_subset:
-      - distribution
-  when: ansible_distribution is not defined
+# Use raw first so this works when inventory already pins a not-yet-installed
+# /usr/bin/python3.9 interpreter for rhel8 cloud stack hosts.
+- name: Ensure Python 3.9 is installed on RHEL 8
+  ansible.builtin.raw: |
+    set -e
+    if ! grep -qE 'Red Hat Enterprise Linux release 8\.' /etc/redhat-release 2>/dev/null; then
+      exit 0
+    fi
+    if [ -x /usr/bin/python3.9 ]; then exit 0; fi
+    dnf install -y python39
+  register: _rhel8_python39
+  changed_when: >-
+    'Installing' in (_rhel8_python39.stdout | default(''))
+    or 'Upgrading' in (_rhel8_python39.stdout | default(''))
 
-- name: Configure Python 3.9 for Ansible on RHEL 8
-  when:
-    - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version | string == '8'
+- name: Pin Python 3.9 for Ansible modules on RHEL 8
+  ansible.builtin.raw: grep -qE 'Red Hat Enterprise Linux release 8\.' /etc/redhat-release
+  register: _rhel8_check
+  failed_when: false
+  changed_when: false
+
+- name: Configure Python 3.9 interpreter for Ansible on RHEL 8
+  when: _rhel8_check.rc == 0
   block:
-    - name: Ensure Python 3.9 is installed on RHEL 8
-      ansible.builtin.raw: |
-        set -e
-        if [ -x /usr/bin/python3.9 ]; then exit 0; fi
-        dnf install -y python39
-      register: _rhel8_python39
-      changed_when: >-
-        'Installing' in (_rhel8_python39.stdout | default(''))
-        or 'Upgrading' in (_rhel8_python39.stdout | default(''))
-
     - name: Pin Python 3.9 for Ansible modules on RHEL 8
       ansible.builtin.set_fact:
         ansible_python_interpreter: /usr/bin/python3.9

--- a/linux/multi_profile_compliance.yml
+++ b/linux/multi_profile_compliance.yml
@@ -4,7 +4,6 @@
   become: true
   gather_facts: false
   vars:
-    ansible_python_interpreter: auto_silent
     compliance_profile: undef
 
   tasks:

--- a/linux/multi_profile_compliance.yml
+++ b/linux/multi_profile_compliance.yml
@@ -2,10 +2,19 @@
 - name: Apply compliance profile
   hosts: "{{ _hosts | default(omit) }}"
   become: true
+  gather_facts: false
   vars:
+    ansible_python_interpreter: auto_silent
     compliance_profile: undef
 
   tasks:
+    - name: Ensure RHEL 8 uses a supported Python for Ansible modules
+      ansible.builtin.include_role:
+        name: demo.cloud.ensure_rhel8_python
+
+    - name: Gather facts
+      ansible.builtin.setup:
+
     - name: Check os type
       ansible.builtin.assert:
         that: "ansible_os_family == 'RedHat'"

--- a/linux/multi_profile_compliance_report.yml
+++ b/linux/multi_profile_compliance_report.yml
@@ -105,6 +105,8 @@
       when: use_httpd | bool
 
     - name: Tag instance as {{ compliance_profile | upper }}_OUT_OF_COMPLIANCE  # noqa name[template]
+      vars:
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
       delegate_to: localhost
       amazon.aws.ec2_tag:
         region: "{{ placement.region }}"

--- a/linux/multi_profile_compliance_report.yml
+++ b/linux/multi_profile_compliance_report.yml
@@ -3,7 +3,6 @@
   hosts: '{{ _hosts | default(omit) }}'
   become: true
   gather_facts: false
-  serial: 1
 
   vars:
     ansible_python_interpreter: auto_silent

--- a/linux/multi_profile_compliance_report.yml
+++ b/linux/multi_profile_compliance_report.yml
@@ -2,8 +2,10 @@
 - name: Generate OpenSCAP compliance report
   hosts: '{{ _hosts | default(omit) }}'
   become: true
+  gather_facts: false
 
   vars:
+    ansible_python_interpreter: auto_silent
     openscap_packages:
       - openscap-scanner
       - openscap-utils
@@ -13,6 +15,13 @@
     use_httpd: true
 
   tasks:
+    - name: Ensure RHEL 8 uses a supported Python for Ansible modules
+      ansible.builtin.include_role:
+        name: demo.cloud.ensure_rhel8_python
+
+    - name: Gather facts
+      ansible.builtin.setup:
+
     - name: Assert memory meets minimum requirements
       ansible.builtin.assert:
         that:

--- a/linux/multi_profile_compliance_report.yml
+++ b/linux/multi_profile_compliance_report.yml
@@ -67,14 +67,19 @@
           ansible.builtin.service_facts:
 
         - name: Enable firewall http service
-          ansible.posix.firewalld:
-            service: http
-            state: enabled
-            immediate: true
-            permanent: true
+          ansible.builtin.command: firewall-cmd --permanent --add-service=http
+          register: _firewalld_http
+          changed_when: "'ALREADY_ENABLED' not in (_firewalld_http.stdout | default(''))"
           when:
             - "'firewalld.service' in ansible_facts.services"
             - ansible_facts.services["firewalld.service"].state == "running"
+
+        - name: Reload firewalld for http service
+          ansible.builtin.command: firewall-cmd --reload
+          when:
+            - "'firewalld.service' in ansible_facts.services"
+            - ansible_facts.services["firewalld.service"].state == "running"
+            - _firewalld_http is changed
 
         - name: Disable httpd welcome page
           ansible.builtin.file:

--- a/linux/multi_profile_compliance_report.yml
+++ b/linux/multi_profile_compliance_report.yml
@@ -3,6 +3,7 @@
   hosts: '{{ _hosts | default(omit) }}'
   become: true
   gather_facts: false
+  serial: 1
 
   vars:
     ansible_python_interpreter: auto_silent
@@ -25,9 +26,14 @@
     - name: Assert memory meets minimum requirements
       ansible.builtin.assert:
         that:
-          - ansible_memfree_mb >= 1000
+          - ansible_memory_mb.nocache.free >= 1000
           - ansible_memtotal_mb >= 2000
-        fail_msg: "OpenSCAP is a memory intensive operation, the specified enepoint does not meet minimum requirements. See https://access.redhat.com/articles/6999111 for details."
+        fail_msg: >-
+          OpenSCAP is a memory intensive operation and this host does not meet
+          minimum requirements (need >= 1 GB available and 2 GB total RAM).
+          See https://access.redhat.com/articles/6999111 for details.
+          Current available: {{ ansible_memory_mb.nocache.free }} MB,
+          total: {{ ansible_memtotal_mb }} MB.
 
     - name: Get our facts straight
       ansible.builtin.set_fact:

--- a/linux/multi_profile_compliance_report.yml
+++ b/linux/multi_profile_compliance_report.yml
@@ -75,6 +75,7 @@
 
         - name: Reload firewalld for http service
           ansible.builtin.command: firewall-cmd --reload
+          changed_when: true
           when:
             - "'firewalld.service' in ansible_facts.services"
             - ansible_facts.services["firewalld.service"].state == "running"

--- a/linux/multi_profile_compliance_report.yml
+++ b/linux/multi_profile_compliance_report.yml
@@ -5,7 +5,6 @@
   gather_facts: false
 
   vars:
-    ansible_python_interpreter: auto_silent
     openscap_packages:
       - openscap-scanner
       - openscap-utils

--- a/linux/multi_profile_compliance_report.yml
+++ b/linux/multi_profile_compliance_report.yml
@@ -46,7 +46,12 @@
           ansible.builtin.dnf:
             name: httpd
             state: present
-          notify: Restart httpd
+
+        - name: Start and enable httpd
+          ansible.builtin.service:
+            name: httpd
+            state: started
+            enabled: true
 
         - name: Override report directory
           ansible.builtin.set_fact:
@@ -70,6 +75,10 @@
             path: /etc/httpd/conf.d/welcome.conf
             state: absent
           notify: Restart httpd
+
+    - name: Flush handlers before publishing report URL
+      ansible.builtin.meta: flush_handlers
+      when: use_httpd | bool
 
     - name: Ensure report directory exists
       ansible.builtin.file:

--- a/linux/remediate_out_of_compliance.yml
+++ b/linux/remediate_out_of_compliance.yml
@@ -3,8 +3,6 @@
   hosts: "{{ compliance_profile | default('stig') | upper }}_OUT_OF_COMPLIANCE"
   become: true
   gather_facts: false
-  vars:
-    ansible_python_interpreter: auto_silent
 
   tasks:
     - name: Ensure RHEL 8 uses a supported Python for Ansible modules

--- a/linux/remediate_out_of_compliance.yml
+++ b/linux/remediate_out_of_compliance.yml
@@ -2,7 +2,18 @@
 - name: Apply compliance profile as part of workflow.
   hosts: "{{ compliance_profile | default('stig') | upper }}_OUT_OF_COMPLIANCE"
   become: true
+  gather_facts: false
+  vars:
+    ansible_python_interpreter: auto_silent
+
   tasks:
+    - name: Ensure RHEL 8 uses a supported Python for Ansible modules
+      ansible.builtin.include_role:
+        name: demo.cloud.ensure_rhel8_python
+
+    - name: Gather facts
+      ansible.builtin.setup:
+
     - name: Check os type
       ansible.builtin.assert:
         that: "ansible_os_family == 'RedHat'"

--- a/linux/setup.yml
+++ b/linux/setup.yml
@@ -525,6 +525,8 @@ controller_templates:
 
   - name: "LINUX | Multi-profile Compliance Report"
     job_type: run
+    organization: Ansible Product Demos (APD)
+    execution_environment: TMM AWS EE
     inventory: Ansible Product Demos Inventory
     project: "Ansible Product Demos"
     playbook: "linux/multi_profile_compliance_report.yml"

--- a/linux/setup.yml
+++ b/linux/setup.yml
@@ -525,8 +525,6 @@ controller_templates:
 
   - name: "LINUX | Multi-profile Compliance Report"
     job_type: run
-    organization: Ansible Product Demos (APD)
-    execution_environment: TMM AWS EE
     inventory: Ansible Product Demos Inventory
     project: "Ansible Product Demos"
     playbook: "linux/multi_profile_compliance_report.yml"


### PR DESCRIPTION
## Summary
- Bootstrap RHEL 8 with `demo.cloud.ensure_rhel8_python` before fact gathering in the compliance report, multi-profile enforce, and workflow enforce playbooks so cloud stack instances work with ansible-core 2.16.
- Fix compliance report publishing: start httpd explicitly, use `firewall-cmd` instead of `ansible.posix.firewalld` on Python 3.9 (interpreter binding mismatch after python3.9 pin), and check available memory (`nocache.free`).
- Use `ansible_playbook_python` on delegated `ec2_tag` tasks so localhost uses the EE Python with boto3 instead of inheriting the managed host's python3.9 pin.
- Ensures **LINUX | Multi-profile Compliance Report** and **LINUX | Compliance Enforce** work standalone on cloud stack hosts, not only when run through the compliance workflow.

## Review updates (c02ed78)
- Removed unnecessary `ansible_python_interpreter: auto_silent` from compliance playbooks.
- Reverted **TMM AWS EE** on the report job; kept default APD EE.

## Test plan
- [x] Run **LINUX | Multi-profile Compliance Report** against `aws_rhel8:aws_rhel9` with CIS profile and `use_httpd=true`
- [x] Confirm HTML reports are reachable at the printed URLs on both hosts
- [x] Confirm EC2 `Compliance` tagging completes without boto3/interpreter errors
- [ ] Run **LINUX | Compliance Enforce** standalone against tagged `CIS_OUT_OF_COMPLIANCE` hosts on RHEL 8
- [ ] Run full **Linux | Compliance Workflow** end-to-end