### PR TITLE
Add LINUX job template to add SSH public keys via survey

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -60,6 +60,8 @@ When bootstrapping AAP manually, you can pre-load the SSH key with the `vault_ap
 
 For standalone runs of **Cloud / AWS | Create Keypair**, paste a public key in the optional survey field only if **APD Machine Credential** does not include a private key.
 
+To add **your own** public key for manual SSH to demo Linux hosts (without exporting the credential private key), run [**LINUX | Add SSH Public Key**](../linux/docs/linux-install-ssh-key.md) after the stack is deployed.
+
 ## Suggested Usage
 
 ### Deploy Cloud Stack in AWS

--- a/cloud/docs/deploy-cloud-stack.md
+++ b/cloud/docs/deploy-cloud-stack.md
@@ -53,6 +53,16 @@ graph LR
 - Mixed OS fleet (RHEL 8, RHEL 9, Windows Server) reflects real customer environments
 - Dynamic inventory automatically imports all provisioned VMs into AAP
 
+## Manual SSH access
+
+Linux VMs launch with the `aws-test-key` EC2 keypair (public key derived from **APD Machine Credential**). AAP cannot export that private key after it is saved.
+
+To SSH in with **your own** key (for example Ed25519), run [**LINUX | Add SSH Public Key**](../../linux/docs/linux-install-ssh-key.md) against `aws_rhel*` or a single host, then connect as `ec2-user`:
+
+```bash
+ssh -i ~/.ssh/your-private-key ec2-user@<instance-ip>
+```
+
 ## Presenter walkthrough
 
 1. **Show the survey:** Walk through each field — region, owner, environment. Explain how surveys make self-service provisioning safe.
@@ -68,4 +78,5 @@ graph LR
 |------|-------------|
 | 🩹 [Patch Cloud Stack in AWS](./patch-cloud-stack.md) | Run this after deploying to demonstrate day-2 patching |
 | 💥 [Destroy Cloud Stack in AWS](./cloud-destroy-stack.md) | Tear down everything when done |
+| 🐧 [Add SSH Public Key](../../linux/docs/linux-install-ssh-key.md) | Add your public key for manual SSH to RHEL hosts |
 | 🐧 [Fact Scan](../../linux/docs/linux-fact-scan.md) | Gather facts from the newly deployed RHEL hosts |

--- a/docs/_data/demos.yml
+++ b/docs/_data/demos.yml
@@ -478,6 +478,23 @@
     playbooks: 1
   github_path: linux/run_script.yml
 
+- slug: linux-install-ssh-key
+  readme_path: linux/docs/linux-install-ssh-key.md
+  url: /demos/linux-install-ssh-key/
+  title: "Add SSH Public Key"
+  category: linux
+  status: active
+  tags:
+    - Playbook
+    - Survey
+  thumbnail:
+    gradient: "linear-gradient(135deg, #d13438 0%, #7a0000 100%)"
+    icon: "🐧"
+  blurb: "Add an SSH public key to a Linux user's authorized_keys file on one or more hosts."
+  stats:
+    playbooks: 1
+  github_path: linux/install_ssh_key.yml
+
 - slug: linux-fact-scan
   readme_path: linux/docs/linux-fact-scan.md
   url: /demos/linux-fact-scan/

--- a/linux/README.md
+++ b/linux/README.md
@@ -32,6 +32,7 @@ This category of demos shows examples of linux operations and management with An
 | [**Start Service**](docs/linux-start-service.md) | Start a named service on a target system. |
 | [**Stop Service**](docs/linux-stop-service.md) | Stop a named service on a target system. |
 | [**Run Shell Script**](docs/linux-run-shell-script.md) | Execute a shell script or command across a group of systems as root, with RBAC-controlled access. |
+| [**Add SSH Public Key**](docs/linux-install-ssh-key.md) | Add an SSH public key to a Linux user's authorized_keys file on one or more hosts. |
 | [**Fact Scan**](docs/linux-fact-scan.md) | Run a fact, package, and service scan against a system and store results in the AAP fact cache. |
 | [**Podman Webserver**](docs/linux-podman-webserver.md) | Install and run an Apache webserver in a Podman container with a configurable home page message. |
 | [**System Roles**](docs/linux-system-roles.md) | Apply RHEL System Roles (e.g. SELinux, timesync) to servers using the redhat.rhel_system_roles collection. |
@@ -67,6 +68,8 @@ Edit the `Linux / System Roles` job to include the list of roles that you wish t
 **Linux / Patching** - Use this job to apply updates or audit for missing updates and produce an html report of systems with missing updates. For a more comprehensive patching workflow that includes EC2 snapshots, pre/post verification, automatic rollback, and a compliance report across both RHEL and Windows, see [Patch Cloud Stack in AWS](../cloud/docs/patch-cloud-stack.md) in the Cloud demos. See the end of the job for the URL to view the report. In other environments this report could be uploaded to a wiki, email, other system. This demo also shows installing a webserver on a linux server. The report is places on the system defined by the `report_server` variable. By default, `report_server` is configured as `reports`. This may be overridden with `extra_vars` on the Job Template.
 
 **Linux / Run Shell Script** - Use this job to demonstrate running shell commands or an existing shell script across a group of systems as root. This can be preferred over using Ad-Hoc commands due to the ability to control usage with RBAC. This is helpful in showing the scalable of execution of an existing shell script. It is always recommended to convert shell scripts to playbooks over time. Example usage would be getting the public key used in the environment with the command `cat .ssh/authorized_keys`.
+
+**Linux / Add SSH Public Key** - Use this job to add your SSH public key (Ed25519, RSA, or ECDSA) to demo Linux hosts through the survey. Run it against `aws_rhel*` or another host pattern to enable manual SSH access without editing each system's `authorized_keys` by hand. See [Add SSH Public Key](docs/linux-install-ssh-key.md) for the full walkthrough. This is separate from **APD Machine Credential**, which Ansible uses for automation and cannot be exported from AAP after save.
 
 **Linux / Fact Scan** - Use this job to demonstrate the use of the Ansible Fact Cache, Ansible facts, and the ability to query installed packages and running services on a system.
 

--- a/linux/docs/linux-fact-scan.md
+++ b/linux/docs/linux-fact-scan.md
@@ -26,3 +26,4 @@ Scans hosts and gathers package and service facts. This populates the AAP fact c
 |------|-------------|
 | 🐧 [Troubleshoot](./linux-troubleshoot.md) | Active troubleshooting beyond passive fact gathering |
 | 🚀 [Deploy Cloud Stack in AWS](../../cloud/docs/deploy-cloud-stack.md) | Deploy hosts to scan |
+| 🐧 [Add SSH Public Key](./linux-install-ssh-key.md) | Add your public key before SSH troubleshooting |

--- a/linux/docs/linux-install-ssh-key.md
+++ b/linux/docs/linux-install-ssh-key.md
@@ -1,0 +1,55 @@
+# Add SSH Public Key
+
+
+Adds your SSH public key to a Linux user's `authorized_keys` file on one or more hosts. Paste an Ed25519, RSA, or ECDSA public key in the survey to enable manual SSH access without logging in as root on each box or recovering the private key stored in **APD Machine Credential**.
+
+This job is idempotent: re-running with the same key does not create duplicates.
+
+## Prerequisites
+
+- Linux hosts in the **Ansible Product Demos Inventory**
+- SSH connectivity via **APD Machine Credential** (Ansible still needs an existing path in to run the job)
+- The target user must exist on the system (for example, `ec2-user` on RHEL EC2 instances from [Deploy Cloud Stack in AWS](../../cloud/docs/deploy-cloud-stack.md))
+
+## Survey prompts
+
+| Prompt | Variable | Type | Required | Default | Description |
+|--------|----------|------|----------|---------|-------------|
+| Server Name or Pattern | `_hosts` | text | Yes | | Limit or pattern, for example `aws_rhel9` or `aws_rhel*` |
+| SSH User | `ssh_user` | text | Yes | `ec2-user` | Linux account that receives the key |
+| SSH Public Key | `ssh_public_key` | textarea | Yes | | Full public key line from `cat ~/.ssh/id_ed25519.pub` |
+
+## Job templates
+
+| Template | Playbook | Description |
+|----------|----------|-------------|
+| LINUX ǀ Add SSH Public Key | [`linux/install_ssh_key.yml`](../install_ssh_key.yml) | Adds the survey public key to the target user's `authorized_keys` file |
+
+## Why it matters
+
+- **APD Machine Credential** stores a private key for Ansible automation, but AAP does not let you export it after save
+- Operators often want their **own** key for interactive SSH during demos, troubleshooting, or presenter prep
+- Survey-driven, RBAC-controlled access beats ad-hoc `authorized_keys` edits on every host
+- Works across host patterns (`aws_rhel*`) so one launch updates every matching RHEL worker
+
+## Presenter walkthrough
+
+1. **Generate a key (if needed):** `ssh-keygen -t ed25519 -f ~/.ssh/apd-demo -N ""`
+2. **Copy the public key:** `cat ~/.ssh/apd-demo.pub`
+3. **Launch the job:** Set `_hosts` to `aws_rhel*` (or a single host), leave **SSH User** as `ec2-user`, paste the public key
+4. **Verify:** `ssh -i ~/.ssh/apd-demo ec2-user@<instance-ip>`
+5. **Call out:** This adds your key alongside the cloud stack keypair; it does not replace **APD Machine Credential**
+
+## Talking points
+
+- Ed25519, RSA, and other standard OpenSSH public key formats are supported
+- The playbook uses `ansible.posix.authorized_key` with `exclusive: false`, so existing keys (including `aws-test-key`) remain
+- Same pattern customers use for onboarding operators onto fleets without sharing one break-glass credential
+
+## Related demos
+
+| Demo | Description |
+|------|-------------|
+| 🚀 [Deploy Cloud Stack in AWS](../../cloud/docs/deploy-cloud-stack.md) | Provisions the demo EC2 hosts this job is commonly run against |
+| 🐧 [Troubleshoot](./linux-troubleshoot.md) | Investigate hosts after you SSH in manually |
+| 🐧 [Run Shell Script](./linux-run-shell-script.md) | Run ad-hoc commands via AAP instead of SSH |

--- a/linux/install_ssh_key.yml
+++ b/linux/install_ssh_key.yml
@@ -1,0 +1,27 @@
+---
+- name: Add SSH Public Key
+  hosts: "{{ _hosts | default(omit) }}"
+  become: true
+  gather_facts: false
+  vars:
+    ssh_user: ec2-user
+    ssh_public_key: undef
+
+  tasks:
+    - name: Validate SSH public key was provided
+      ansible.builtin.assert:
+        that:
+          - ssh_public_key is defined
+          - ssh_public_key | trim | length > 0
+        fail_msg: Provide a full SSH public key line in the survey (for example, ssh-ed25519 AAAA... comment).
+
+    - name: Install SSH public key for user
+      ansible.posix.authorized_key:
+        user: "{{ ssh_user }}"
+        state: present
+        key: "{{ ssh_public_key | trim }}"
+        exclusive: false
+
+    - name: Confirm key installation
+      ansible.builtin.debug:
+        msg: "Installed SSH public key for {{ ssh_user }} on {{ inventory_hostname }}."

--- a/linux/setup.yml
+++ b/linux/setup.yml
@@ -289,6 +289,47 @@ controller_templates:
           variable: shell_script
           required: true
 
+  - name: "LINUX | Add SSH Public Key"
+    description: >-
+      Add an SSH public key to a Linux user's authorized_keys file on one or
+      more hosts. Useful for granting manual SSH access across demo VMs.
+    job_type: run
+    inventory: Ansible Product Demos Inventory
+    project: Ansible Product Demos
+    playbook: linux/install_ssh_key.yml
+    notification_templates_started: Telemetry
+    notification_templates_success: Telemetry
+    notification_templates_error: Telemetry
+    credentials:
+      - APD Machine Credential
+    survey_enabled: true
+    survey:
+      name: ''
+      description: ''
+      spec:
+        - question_name: Server Name or Pattern
+          question_description: >-
+            aws_rhel9 for one host, or aws_rhel* to add the key to every
+            matching RHEL worker.
+          type: text
+          variable: _hosts
+          required: true
+        - question_name: SSH User
+          question_description: >-
+            Linux account that should receive the key. Use ec2-user for RHEL
+            EC2 instances in the cloud stack.
+          type: text
+          variable: ssh_user
+          required: true
+          default: ec2-user
+        - question_name: SSH Public Key
+          question_description: >-
+            Paste the full public key line, for example ssh-ed25519 AAAA...
+            comment.
+          type: textarea
+          variable: ssh_public_key
+          required: true
+
   - name: "LINUX | Fact Scan"
     project: "Ansible Product Demos"
     playbook: linux/fact_scan.yml


### PR DESCRIPTION
## Summary

- Adds **LINUX | Add SSH Public Key**, a survey-driven job template that adds an operator's SSH public key to a Linux user's `authorized_keys` on one or more hosts (supports Ed25519, RSA, and other standard OpenSSH formats).
- Includes playbook, AAP setup entry, GitHub Pages demo metadata, and documentation with presenter walkthrough.
- Cross-links from cloud stack docs for the common post-deploy flow: operators cannot export the private key from **APD Machine Credential**, but can add their own key for manual SSH to RHEL demo VMs.

## Test plan

- [ ] Run **APD | Single demo setup** with `linux` and confirm **LINUX | Add SSH Public Key** is created
- [ ] Launch against `aws_rhel*` with an Ed25519 public key and verify job succeeds
- [ ] Confirm manual SSH works: `ssh -i ~/.ssh/id_ed25519 ec2-user@<host-ip>`
- [ ] Re-run the job and confirm idempotency (no duplicate key lines)
- [ ] Review demo page content at `/demos/linux-install-ssh-key/` after Pages deploy