### PR TITLE
Allow TCP 27199 on cloud stack security group for AAP mesh

### DIFF
--- a/cloud/create_vpc.yml
+++ b/cloud/create_vpc.yml
@@ -76,6 +76,7 @@
               - 3389  # RDP
               - 9090  # Cockpit
               - 9095  # Kafka EDA external listener (aws_kafka config drift)
+              - 27199  # AAP receptor mesh (survives idempotent cloud stack redeploy)
             cidr_ip: 0.0.0.0/0
           - proto: icmp
             to_port: -1


### PR DESCRIPTION
## Summary
- Add TCP **27199** to the `aws-test-sg` inbound rules in **Cloud | AWS | Create VPC** (`cloud/create_vpc.yml`)
- Matches the existing pattern for port **9095** (Kafka EDA): include mesh in the canonical SG definition so idempotent **Deploy Cloud Stack in AWS** runs do not drop the port

## Context
Re-running the cloud stack workflow recreates the security group rule set from the playbook. Any port opened manually (or by another demo) but not listed in Create VPC is removed on redeploy, which breaks AAP receptor mesh connectivity.

## Test plan
- [ ] Sync project from this branch and run **Deploy Cloud Stack in AWS** (or **Cloud | AWS | Create VPC**) against an existing stack
- [ ] Confirm `aws-test-sg` has inbound TCP 27199 from `0.0.0.0/0`
- [ ] Re-run Deploy Cloud Stack idempotently and verify port 27199 remains open
- [ ] Confirm AAP mesh/receptor connectivity is restored after redeploy


Made with [Cursor](https://cursor.com)